### PR TITLE
Add events to google calendar and handle duplicate display

### DIFF
--- a/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendar.kt
+++ b/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendar.kt
@@ -1,11 +1,11 @@
 package com.example.phinui.data.calendar
 
+import android.net.Uri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
-import android.net.Uri
 import java.time.LocalDate
 import java.time.ZoneId
 
@@ -15,7 +15,7 @@ import java.time.ZoneId
  */
 object GoogleCalendarRepository {
 
-// Fetches events for the week you choose to look at in the app.
+    // Fetches events for the week you choose to look at in the app.
     suspend fun fetchWeekEvents(
         accessToken: String,
         weekStart: LocalDate,
@@ -27,9 +27,8 @@ object GoogleCalendarRepository {
         // A page token = a pointer to the next “page” of results.
         var pageToken: String? = null
 
-
         val weekStartTimestamp = weekStart.atStartOfDay(zone).toInstant().toString()
-        val weekEndTimestamp  = weekStart.plusDays(7).atStartOfDay(zone).toInstant().toString()
+        val weekEndTimestamp = weekStart.plusDays(7).atStartOfDay(zone).toInstant().toString()
 
         do {
             val url = buildEventsRequestUrl(
@@ -67,50 +66,7 @@ object GoogleCalendarRepository {
                 if (items != null) {
                     for (i in 0 until items.length()) {
                         val item = items.getJSONObject(i)
-
-                        val id = item.optString("id")
-                        val title = item.optString("summary", "(No title)")
-
-                        val startObj = item.optJSONObject("start")
-                        val endObj = item.optJSONObject("end")
-
-                        val start = startObj?.optString("dateTime")?.ifBlank { null }
-                            ?: startObj?.optString("date")?.ifBlank { null }
-                            ?: ""
-
-                        val end = endObj?.optString("dateTime")?.ifBlank { null }
-                            ?: endObj?.optString("date")?.ifBlank { null }
-                            ?: ""
-
-                        // for reminders
-                        val remindersList = mutableListOf<Int>()
-                        val remindersObj = item.optJSONObject("reminders")
-                        if (remindersObj != null) {
-                            val overrides = remindersObj.optJSONArray("overrides")
-                            if (overrides != null) {
-                                for (j in 0 until overrides.length()) {
-                                    val override = overrides.getJSONObject(j)
-                                    val minutes = override.optInt("minutes", -1)
-                                    if (minutes >= 0) {
-                                        remindersList.add(minutes)
-                                    }
-                                }
-                            }
-                        }
-
-                        val location = item.optString("location").ifBlank { null }
-
-                        events.add(
-                            CalendarEvent(
-                                id = id,
-                                title = title,
-                                start = start,
-                                end = end,
-                                location = location,
-                                reminderMinutes = remindersList,
-                                source = CalendarSource.GOOGLE
-                            )
-                        )
+                        events.add(parseGoogleEvent(item))
                     }
                 }
 
@@ -121,6 +77,48 @@ object GoogleCalendarRepository {
         } while (pageToken != null)
 
         events
+    }
+
+    // Inserts a new event into the user's primary Google Calendar
+    suspend fun insertEvent(
+        accessToken: String,
+        event: CalendarEvent,
+        zone: ZoneId = ZoneId.systemDefault()
+    ): CalendarEvent = withContext(Dispatchers.IO) {
+
+        val url = URL("https://www.googleapis.com/calendar/v3/calendars/primary/events")
+        val connection = url.openConnection() as HttpURLConnection
+
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Authorization", "Bearer $accessToken")
+        connection.setRequestProperty("Accept", "application/json")
+        connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8")
+        connection.doOutput = true
+
+        try {
+            val requestBody = buildInsertEventBody(event, zone).toString()
+
+            connection.outputStream.bufferedWriter(Charsets.UTF_8).use { writer ->
+                writer.write(requestBody)
+                writer.flush()
+            }
+
+            val code = connection.responseCode
+            val body = if (code in 200..299) {
+                connection.inputStream.bufferedReader().readText()
+            } else {
+                connection.errorStream?.bufferedReader()?.readText() ?: ""
+            }
+
+            if (code !in 200..299) {
+                throw RuntimeException("Calendar insert error ($code): $body")
+            }
+
+            val root = JSONObject(body)
+            parseGoogleEvent(root)
+        } finally {
+            connection.disconnect()
+        }
     }
 
     // Builds the full google calendar api url string
@@ -145,5 +143,89 @@ object GoogleCalendarRepository {
         }
 
         return builder.build().toString()
+    }
+
+    // Builds the JSON body for inserting an event into Google Calendar
+    private fun buildInsertEventBody(
+        event: CalendarEvent,
+        zone: ZoneId
+    ): JSONObject {
+        val timeZoneId = zone.id
+
+        return JSONObject().apply {
+            put("summary", event.title)
+
+            if (!event.location.isNullOrBlank()) {
+                put("location", event.location)
+            }
+
+            put(
+                "start",
+                JSONObject().apply {
+                    put("dateTime", normalizeDateTime(event.start))
+                    put("timeZone", timeZoneId)
+                }
+            )
+
+            put(
+                "end",
+                JSONObject().apply {
+                    put("dateTime", normalizeDateTime(event.end))
+                    put("timeZone", timeZoneId)
+                }
+            )
+        }
+    }
+
+    // Parses a Google Calendar API event object into CalendarEvent
+    private fun parseGoogleEvent(item: JSONObject): CalendarEvent {
+        val id = item.optString("id")
+        val title = item.optString("summary", "(No title)")
+
+        val startObj = item.optJSONObject("start")
+        val endObj = item.optJSONObject("end")
+
+        val start = startObj?.optString("dateTime")?.ifBlank { null }
+            ?: startObj?.optString("date")?.ifBlank { null }
+            ?: ""
+
+        val end = endObj?.optString("dateTime")?.ifBlank { null }
+            ?: endObj?.optString("date")?.ifBlank { null }
+            ?: ""
+
+        val remindersList = mutableListOf<Int>()
+        val remindersObj = item.optJSONObject("reminders")
+        if (remindersObj != null) {
+            val overrides = remindersObj.optJSONArray("overrides")
+            if (overrides != null) {
+                for (j in 0 until overrides.length()) {
+                    val override = overrides.getJSONObject(j)
+                    val minutes = override.optInt("minutes", -1)
+                    if (minutes >= 0) {
+                        remindersList.add(minutes)
+                    }
+                }
+            }
+        }
+
+        val location = item.optString("location").ifBlank { null }
+
+        return CalendarEvent(
+            id = id,
+            title = title,
+            start = start,
+            end = end,
+            location = location,
+            reminderMinutes = remindersList,
+            source = CalendarSource.GOOGLE
+        )
+    }
+
+    // Ensures datetime strings are in a valid format for Google Calendar API
+    private fun normalizeDateTime(dateTime: String): String {
+        return when {
+            dateTime.length == 16 && dateTime.contains('T') -> "$dateTime:00"
+            else -> dateTime
+        }
     }
 }

--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -29,6 +29,8 @@ import com.example.phinui.notifications.ReminderScheduler
 import com.example.phinui.viewmodel.CalendarViewModel
 import com.example.phinui.viewmodel.CalendarViewModelFactory
 import com.example.phinui.screens.MapScreen
+import kotlinx.coroutines.withContext
+import com.example.phinui.viewmodel.AddEventResult
 
 
 @Composable
@@ -79,29 +81,133 @@ fun PhinNavHost(
         }
 
         composable(Routes.EVENTS) {
+            val context = LocalContext.current
+            val activity = context as ComponentActivity
+
+            val reminderScheduler = remember {
+                ReminderScheduler(context.applicationContext)
+            }
+
+            val factory = remember {
+                CalendarViewModelFactory(reminderScheduler)
+            }
+
+            val calendarViewModel: CalendarViewModel = viewModel(
+                viewModelStoreOwner = activity,
+                factory = factory
+            )
+
             EventsScreen(
                 events = allEvents,
                 onEventClick = { event ->
-                    if (savedEvents.none { it.id == event.id }) {
-                        savedEvents.add(event)
-                        // Save to persistent storage
-                        coroutineScope.launch(Dispatchers.IO) {
-                            storeEvent.saveEvent(event)
-                        }
+                    val googleEvents = calendarViewModel.eventsGroupedByDate.values.flatten()
+                    val isSignedInToGoogle = calendarViewModel.googleAccessToken != null
 
-                        // notification for adding event
-                        Toast.makeText(
-                            context,
-                            "${event.title} added to your calendar.",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                    val existsLocally = savedEvents.any { sameCalendarEvent(it, event) }
+                    val existsInGoogle = googleEvents.any { sameCalendarEvent(it, event) }
+
+                    if (isSignedInToGoogle) {
+                        if (existsInGoogle) {
+                            Toast.makeText(
+                                context,
+                                "${event.title} already in your Google Calendar.",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            coroutineScope.launch {
+                                try {
+                                    when (val result = calendarViewModel.addEventToAppropriateCalendar(event)) {
+                                        is AddEventResult.ShouldSaveLocally -> {
+                                            if (!existsLocally) {
+                                                savedEvents.add(event)
+
+                                                withContext(Dispatchers.IO) {
+                                                    storeEvent.saveEvent(event)
+                                                }
+                                            }
+
+                                            Toast.makeText(
+                                                context,
+                                                "${event.title} added to your local calendar.",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+
+                                        is AddEventResult.AddedToGoogle -> {
+                                            if (savedEvents.none {
+                                                    it.title == result.event.title &&
+                                                            it.start == result.event.start &&
+                                                            it.source == result.event.source
+                                                }) {
+                                                savedEvents.add(result.event)
+                                            }
+
+                                            Toast.makeText(
+                                                context,
+                                                "${event.title} added to your Google Calendar.",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+                                    }
+                                } catch (e: Exception) {
+                                    Toast.makeText(
+                                        context,
+                                        e.message ?: "Failed to add event.",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                            }
+                        }
                     } else {
-                        // notification for event existing in calendar
-                        Toast.makeText(
-                            context,
-                            "${event.title} already in your calendar.",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        if (existsLocally) {
+                            Toast.makeText(
+                                context,
+                                "${event.title} already in your local calendar.",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            coroutineScope.launch {
+                                try {
+                                    when (val result = calendarViewModel.addEventToAppropriateCalendar(event)) {
+                                        is AddEventResult.ShouldSaveLocally -> {
+                                            savedEvents.add(event)
+
+                                            withContext(Dispatchers.IO) {
+                                                storeEvent.saveEvent(event)
+                                            }
+
+                                            Toast.makeText(
+                                                context,
+                                                "${event.title} added to your local calendar.",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+
+                                        is AddEventResult.AddedToGoogle -> {
+                                            if (savedEvents.none {
+                                                    it.title == result.event.title &&
+                                                            it.start == result.event.start &&
+                                                            it.source == result.event.source
+                                                }) {
+                                                savedEvents.add(result.event)
+                                            }
+
+                                            Toast.makeText(
+                                                context,
+                                                "${event.title} added to your Google Calendar.",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+                                    }
+                                } catch (e: Exception) {
+                                    Toast.makeText(
+                                        context,
+                                        e.message ?: "Failed to add event.",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                            }
+                        }
                     }
                 },
                 onAddEventClick = {
@@ -147,18 +253,74 @@ fun PhinNavHost(
         }
 
         composable(Routes.ADD_EVENT) {
+            val context = LocalContext.current
+            val activity = context as ComponentActivity
+
+            val reminderScheduler = remember {
+                ReminderScheduler(context.applicationContext)
+            }
+
+            val factory = remember {
+                CalendarViewModelFactory(reminderScheduler)
+            }
+
+            val calendarViewModel: CalendarViewModel = viewModel(
+                viewModelStoreOwner = activity,
+                factory = factory
+            )
+
             AddEventScreen(
                 onSaveEvent = { newEvent ->
-                    if (allEvents.none { it.id == newEvent.id }) {
-                        allEvents.add(newEvent)
-                    }
+                    coroutineScope.launch {
+                        try {
+                            when (val result = calendarViewModel.addEventToAppropriateCalendar(newEvent)) {
+                                is AddEventResult.ShouldSaveLocally -> {
+                                    if (allEvents.none { it.title == newEvent.title && it.start == newEvent.start }) {
+                                        allEvents.add(newEvent)
+                                    }
 
-                    if (savedEvents.none { it.id == newEvent.id }) {
-                        savedEvents.add(newEvent)
-                    }
+                                    if (savedEvents.none { it.title == newEvent.title && it.start == newEvent.start }) {
+                                        savedEvents.add(newEvent)
+                                    }
 
-                    coroutineScope.launch(Dispatchers.IO) {
-                        storeEvent.saveEvent(newEvent)
+                                    withContext(Dispatchers.IO) {
+                                        storeEvent.saveEvent(newEvent)
+                                    }
+
+                                    Toast.makeText(
+                                        context,
+                                        "${newEvent.title} added to your local calendar.",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+
+                                    navController.popBackStack()
+                                }
+
+                                is AddEventResult.AddedToGoogle -> {
+                                    if (savedEvents.none { it.title == result.event.title && it.start == result.event.start }) {
+                                        savedEvents.add(result.event)
+                                    }
+
+                                    if (allEvents.none { it.title == newEvent.title && it.start == newEvent.start }) {
+                                        allEvents.add(newEvent)
+                                    }
+
+                                    Toast.makeText(
+                                        context,
+                                        "${newEvent.title} added to your Google Calendar.",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+
+                                    navController.popBackStack()
+                                }
+                            }
+                        } catch (e: Exception) {
+                            Toast.makeText(
+                                context,
+                                e.message ?: "Failed to save event.",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
                     }
                 },
                 onBackClick = {
@@ -171,4 +333,10 @@ fun PhinNavHost(
             MapScreen(navController = navController)
         }
     }
+}
+
+// Checks if two events are the same (based on title + start time)
+private fun sameCalendarEvent(a: CalendarEvent, b: CalendarEvent): Boolean {
+    return a.title.trim().equals(b.title.trim(), ignoreCase = true) &&
+            a.start.take(16) == b.start.take(16)
 }

--- a/app/src/main/java/com/example/phinui/screens/AddEventScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/AddEventScreen.kt
@@ -101,7 +101,6 @@ fun AddEventScreen(
 
         Button(
             onClick = {
-
                 val newEvent = CalendarEvent(
                     id = System.currentTimeMillis().toString(),
                     title = eventName,
@@ -113,7 +112,6 @@ fun AddEventScreen(
                 )
 
                 onSaveEvent(newEvent)
-                onBackClick()
             }
         ) {
             Text("Save Event")

--- a/app/src/main/java/com/example/phinui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/CalendarScreen.kt
@@ -87,7 +87,7 @@ fun CalendarScreen(
     // Merge Google events + local saved events for display only
     val googleEvents = eventsGroupedByDate.values.flatten()
     val mergedEvents = (googleEvents + savedEvents)
-        .distinctBy { "${it.source}-${it.id}" }
+        .distinctBy { "${it.title.trim().lowercase()}-${it.start.take(16)}" }
     val displayedEventsGroupedByDate = groupEventsByDateForWeek(mergedEvents, currentWeekStartDate)
 
     //  Authorization launcher (opens Google consent UI)

--- a/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
@@ -19,6 +19,10 @@ import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
 
+sealed class AddEventResult {
+    data class AddedToGoogle(val event: CalendarEvent) : AddEventResult()
+    data object ShouldSaveLocally : AddEventResult()
+}
 class CalendarViewModel(
     private val savedStateHandle: SavedStateHandle,
     private val reminderScheduler: ReminderScheduler
@@ -147,6 +151,20 @@ class CalendarViewModel(
         // Clear persisted state used by this ViewModel
         savedStateHandle["googleAccessToken"] = null
         savedStateHandle["userEmail"] = null
+    }
+
+    // Adds event to Google or local calendar depending on sign-in state
+    suspend fun addEventToAppropriateCalendar(event: CalendarEvent): AddEventResult {
+        val token = googleAccessToken ?: return AddEventResult.ShouldSaveLocally
+
+        val createdEvent = GoogleCalendarRepository.insertEvent(
+            accessToken = token,
+            event = event,
+            zone = ZoneId.systemDefault()
+        )
+
+        loadEventsForCurrentWeek()
+        return AddEventResult.AddedToGoogle(createdEvent)
     }
 
     /*


### PR DESCRIPTION
- added logic so if you are signed into google calendar then event from events screen adds to your google calendar
- added logic so if an event is both in your local calendar and your google calendar it wont display twice (Note: google calendar event takes priority - it will be the one to display when a duplicate occurs if signed into google)