### PR TITLE
Persistent Google Calendar State

### DIFF
--- a/app/src/main/java/com/example/phinui/data/authorization/GoogleCalendarSessionStorage.kt
+++ b/app/src/main/java/com/example/phinui/data/authorization/GoogleCalendarSessionStorage.kt
@@ -1,0 +1,41 @@
+package com.example.phinui.data.authorization
+
+import android.content.Context
+
+class GoogleCalendarSessionStorage(context: Context) {
+
+    private val sessionPreference = context.getSharedPreferences(
+        "google_calendar_session",
+        Context.MODE_PRIVATE
+    )
+
+    companion object {
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_USER_EMAIL = "user_email"
+    }
+
+    fun saveSession(
+        accessToken: String,
+        userEmail: String?
+    ) {
+        sessionPreference.edit()
+            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putString(KEY_USER_EMAIL, userEmail)
+            .apply()
+    }
+
+    fun getAccessToken(): String? {
+        return sessionPreference.getString(KEY_ACCESS_TOKEN, null)
+    }
+
+    fun getUserEmail(): String? {
+        return sessionPreference.getString(KEY_USER_EMAIL, null)
+    }
+
+    fun clearSession() {
+        sessionPreference.edit()
+            .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_USER_EMAIL)
+            .apply()
+    }
+}

--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -136,7 +136,10 @@ fun PhinNavHost(
             }
 
             val factory = remember {
-                CalendarViewModelFactory(reminderScheduler)
+                CalendarViewModelFactory(
+                    context = context.applicationContext,
+                    reminderScheduler = reminderScheduler
+                )
             }
 
             val calendarViewModel: CalendarViewModel = viewModel(
@@ -268,7 +271,10 @@ fun PhinNavHost(
             }
 
             val factory = remember {
-                CalendarViewModelFactory(reminderScheduler)
+                CalendarViewModelFactory(
+                    context = context.applicationContext,
+                    reminderScheduler = reminderScheduler
+                )
             }
 
             val calendarViewModel: CalendarViewModel = viewModel(
@@ -300,7 +306,10 @@ fun PhinNavHost(
             }
 
             val factory = remember {
-                CalendarViewModelFactory(reminderScheduler)
+                CalendarViewModelFactory(
+                    context = context.applicationContext,
+                    reminderScheduler = reminderScheduler
+                )
             }
 
             val calendarViewModel: CalendarViewModel = viewModel(

--- a/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
@@ -19,6 +19,7 @@ import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
 import com.example.phinui.data.calendar.CalendarSource
+import com.example.phinui.data.authorization.GoogleCalendarSessionStorage
 
 sealed class AddEventResult {
     data class AddedToGoogle(val event: CalendarEvent) : AddEventResult()
@@ -26,18 +27,21 @@ sealed class AddEventResult {
 }
 class CalendarViewModel(
     private val savedStateHandle: SavedStateHandle,
-    private val reminderScheduler: ReminderScheduler
+    private val reminderScheduler: ReminderScheduler,
+    private val sessionStorage: GoogleCalendarSessionStorage
 ) : ViewModel() {
 
     //  Authorization + calendar data state
     // Restored automatically if process is recreated
     var googleAccessToken by mutableStateOf(
         savedStateHandle.get<String>("googleAccessToken")
+            ?: sessionStorage.getAccessToken()
     )
         private set
 
     var userEmail by mutableStateOf(
         savedStateHandle.get<String>("userEmail")
+            ?: sessionStorage.getUserEmail()
     )
         private set
 
@@ -92,6 +96,11 @@ class CalendarViewModel(
             val email = fetchUserEmail(token)
             userEmail = email
             savedStateHandle["userEmail"] = email
+
+            sessionStorage.saveSession(
+                accessToken = token,
+                userEmail = email
+            )
 
             loadEventsForCurrentWeek()
         }
@@ -152,6 +161,8 @@ class CalendarViewModel(
         // Clear persisted state used by this ViewModel
         savedStateHandle["googleAccessToken"] = null
         savedStateHandle["userEmail"] = null
+
+        sessionStorage.clearSession()
     }
 
     fun goToCurrentWeek() {

--- a/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModelFactory.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModelFactory.kt
@@ -6,9 +6,12 @@ import androidx.lifecycle.ViewModelProvider
 import com.example.phinui.notifications.ReminderScheduler
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
+import android.content.Context
+import com.example.phinui.data.authorization.GoogleCalendarSessionStorage
 
 // in order to allow ReminderScheduler parameter
 class CalendarViewModelFactory(
+    private val context: Context,
     private val reminderScheduler: ReminderScheduler,
 ) : ViewModelProvider.Factory {
 
@@ -19,7 +22,13 @@ class CalendarViewModelFactory(
         if (modelClass.isAssignableFrom(CalendarViewModel::class.java)) {
             // CreationExtras API to get SavedStateHandle
             val savedStateHandle: SavedStateHandle = extras.createSavedStateHandle()
-            return CalendarViewModel(savedStateHandle, reminderScheduler) as T
+            val sessionStorage = GoogleCalendarSessionStorage(context.applicationContext)
+
+            return CalendarViewModel(
+                savedStateHandle = savedStateHandle,
+                reminderScheduler = reminderScheduler,
+                sessionStorage = sessionStorage
+            ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }


### PR DESCRIPTION
Updated google calendar state so it stays persistent as app closes and reopens.
ex: if you sign in and close app, when you reopen app you are still signed in