### PR TITLE
Fix 401 bug for google calendar state

### DIFF
--- a/app/src/main/java/com/example/phinui/data/authorization/GoogleCalendarSessionStorage.kt
+++ b/app/src/main/java/com/example/phinui/data/authorization/GoogleCalendarSessionStorage.kt
@@ -10,22 +10,19 @@ class GoogleCalendarSessionStorage(context: Context) {
     )
 
     companion object {
-        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_CONNECTED = "connected"
         private const val KEY_USER_EMAIL = "user_email"
     }
 
-    fun saveSession(
-        accessToken: String,
-        userEmail: String?
-    ) {
+    fun saveSession(userEmail: String?) {
         sessionPreference.edit()
-            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putBoolean(KEY_CONNECTED, true)
             .putString(KEY_USER_EMAIL, userEmail)
             .apply()
     }
 
-    fun getAccessToken(): String? {
-        return sessionPreference.getString(KEY_ACCESS_TOKEN, null)
+    fun isConnected(): Boolean {
+        return sessionPreference.getBoolean(KEY_CONNECTED, false)
     }
 
     fun getUserEmail(): String? {
@@ -34,7 +31,7 @@ class GoogleCalendarSessionStorage(context: Context) {
 
     fun clearSession() {
         sessionPreference.edit()
-            .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_CONNECTED)
             .remove(KEY_USER_EMAIL)
             .apply()
     }

--- a/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendar.kt
+++ b/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendar.kt
@@ -53,6 +53,10 @@ object GoogleCalendarRepository {
                     connection.errorStream?.bufferedReader()?.readText() ?: ""
                 }
 
+                if (code == 401) {
+                    throw GoogleCalendarUnauthorizedException()
+                }
+
                 // Fail fast if the API returned an error status code
                 if (code !in 200..299) {
                     throw RuntimeException("Calendar API error ($code): $body")

--- a/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendarUnauthorizedException.kt
+++ b/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendarUnauthorizedException.kt
@@ -1,0 +1,4 @@
+package com.example.phinui.data.calendar
+
+class GoogleCalendarUnauthorizedException :
+    Exception("Google Calendar authorization expired.")

--- a/app/src/main/java/com/example/phinui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/CalendarScreen.kt
@@ -42,6 +42,7 @@ import com.example.phinui.ui.components.calendar.EventCard
 import com.example.phinui.ui.components.calendar.WeekDateSelector
 import com.example.phinui.ui.components.calendar.CalendarConnectionCard
 import com.example.phinui.data.events.EventDetails
+import androidx.compose.runtime.LaunchedEffect
 
 // Data formatters
 private val selectedDateTitleFormatter = DateTimeFormatter.ofPattern("EEEE, MMM d")
@@ -72,6 +73,7 @@ fun CalendarScreen(
     val isLoadingEvents = calendarViewModel.isLoadingEvents
     val errorMessage = calendarViewModel.errorMessage
     val eventsGroupedByDate = calendarViewModel.eventsGroupedByDate
+    val isGoogleCalendarConnected = calendarViewModel.isGoogleCalendarConnected
 
     //  Week navigation state
     val currentWeekStartDate = calendarViewModel.currentWeekStartDate
@@ -105,6 +107,23 @@ fun CalendarScreen(
         calendarViewModel.onAuthorizationSuccess(tokenFromResult)
     }
 
+    LaunchedEffect(isGoogleCalendarConnected, googleAccessToken) {
+        if (isGoogleCalendarConnected && googleAccessToken == null) {
+            calendarViewModel.setError(null)
+
+            GoogleAuthManager.startAuthorization(
+                activity = activity,
+                launcher = authorizationLauncher,
+                onAccessToken = { token ->
+                    calendarViewModel.onAuthorizationSuccess(token)
+                },
+                onError = {
+                    calendarViewModel.signOut()
+                }
+            )
+        }
+    }
+
     /*
      * Auto-refresh calendar when screen is reopened
      * Uses ON_RESUME so it updates when navigating back or returning to the app.
@@ -124,14 +143,14 @@ fun CalendarScreen(
     }
 
     // Main Calendar UI Layout
-    Column(modifier.padding(16.dp)) {
+    Column(modifier = modifier.padding(16.dp)) {
 
         //  Header (week range + prev/next)
         CalendarHeader(
             currentWeekStartDate = currentWeekStartDate,
             onRefreshClick = { calendarViewModel.refreshEvents() },
             isRefreshing = isLoadingEvents,
-            isSignedIn = googleAccessToken != null
+            isSignedIn = isGoogleCalendarConnected
         )
 
         Spacer(Modifier.height(12.dp))
@@ -143,7 +162,7 @@ fun CalendarScreen(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            if (googleAccessToken == null) {
+            if (!isGoogleCalendarConnected && googleAccessToken == null) {
                 CalendarConnectionCard(
                     onConnectClick = {
                         calendarViewModel.setError(null)
@@ -169,7 +188,11 @@ fun CalendarScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = userEmail?.let { "Signed in as $it" } ?: "Signed in",
+                        text = when {
+                            googleAccessToken != null && userEmail != null -> "Signed in as $userEmail"
+                            googleAccessToken != null -> "Signed in"
+                            else -> "Reconnecting to Google Calendar..."
+                        },
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.weight(1f)
@@ -190,6 +213,7 @@ fun CalendarScreen(
                                 calendarViewModel.signOut()
                             }
                         },
+                        enabled = isGoogleCalendarConnected,
                         colors = ButtonDefaults.textButtonColors(
                             contentColor = MaterialTheme.colorScheme.primary
                         )
@@ -251,10 +275,17 @@ fun CalendarScreen(
         // Decide what to show based on auth/loading/data state
         when {
             // When no events print:
-            googleAccessToken == null && eventsForSelectedDate.isEmpty() -> {
+            !isGoogleCalendarConnected && eventsForSelectedDate.isEmpty() -> {
                 CalendarEmptyState(
                     title = "Connect your calendar",
                     subtitle = "Sign in to see your events."
+                )
+            }
+
+            isGoogleCalendarConnected && googleAccessToken == null && eventsForSelectedDate.isEmpty() -> {
+                CalendarEmptyState(
+                    title = "Reconnecting...",
+                    subtitle = "Restoring your Google Calendar session."
                 )
             }
 

--- a/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
@@ -20,6 +20,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import com.example.phinui.data.calendar.CalendarSource
 import com.example.phinui.data.authorization.GoogleCalendarSessionStorage
+import com.example.phinui.data.calendar.GoogleCalendarUnauthorizedException
 
 sealed class AddEventResult {
     data class AddedToGoogle(val event: CalendarEvent) : AddEventResult()
@@ -33,11 +34,11 @@ class CalendarViewModel(
 
     //  Authorization + calendar data state
     // Restored automatically if process is recreated
-    var googleAccessToken by mutableStateOf(
-        savedStateHandle.get<String>("googleAccessToken")
-            ?: sessionStorage.getAccessToken()
-    )
+    var googleAccessToken by mutableStateOf<String?>(null)
         private set
+
+    val isGoogleCalendarConnected: Boolean
+        get() = sessionStorage.isConnected()
 
     var userEmail by mutableStateOf(
         savedStateHandle.get<String>("userEmail")
@@ -80,27 +81,16 @@ class CalendarViewModel(
         get() = (0..6).map { offset -> currentWeekStartDate.plusDays(offset.toLong()) }
 
 
-    init {
-        // If a token already exists (restored from state), reload events
-        googleAccessToken?.let {
-            loadEventsForCurrentWeek()
-        }
-    }
-
     // Load current events for the week the authorization is successful
     fun onAuthorizationSuccess(token: String) {
         googleAccessToken = token
-        savedStateHandle["googleAccessToken"] = token
 
         viewModelScope.launch {
             val email = fetchUserEmail(token)
             userEmail = email
             savedStateHandle["userEmail"] = email
 
-            sessionStorage.saveSession(
-                accessToken = token,
-                userEmail = email
-            )
+            sessionStorage.saveSession(userEmail = email)
 
             loadEventsForCurrentWeek()
         }
@@ -159,7 +149,6 @@ class CalendarViewModel(
         eventsGroupedByDate = emptyMap()
 
         // Clear persisted state used by this ViewModel
-        savedStateHandle["googleAccessToken"] = null
         savedStateHandle["userEmail"] = null
 
         sessionStorage.clearSession()
@@ -180,14 +169,21 @@ class CalendarViewModel(
     suspend fun addEventToAppropriateCalendar(event: CalendarEvent): AddEventResult {
         val token = googleAccessToken ?: return AddEventResult.ShouldSaveLocally
 
-        val createdEvent = GoogleCalendarRepository.insertEvent(
-            accessToken = token,
-            event = event,
-            zone = ZoneId.systemDefault()
-        )
+        return try {
+            val createdEvent = GoogleCalendarRepository.insertEvent(
+                accessToken = token,
+                event = event,
+                zone = ZoneId.systemDefault()
+            )
 
-        loadEventsForCurrentWeek()
-        return AddEventResult.AddedToGoogle(createdEvent)
+            loadEventsForCurrentWeek()
+            AddEventResult.AddedToGoogle(createdEvent)
+
+        } catch (e: GoogleCalendarUnauthorizedException) {
+            googleAccessToken = null
+            errorMessage = "Session expired. Please reconnect."
+            AddEventResult.ShouldSaveLocally
+        }
     }
 
     /*
@@ -234,19 +230,18 @@ class CalendarViewModel(
                     reminderScheduler.cancelReminder(removedId)
                 }
 
-            } catch (e: Exception) {
-
-                errorMessage = e.message ?: "Failed to load events."
+            } catch (e: GoogleCalendarUnauthorizedException) {
+                googleAccessToken = null
+                errorMessage = "Session expired. Reconnecting required."
                 eventsGroupedByDate = emptyMap()
 
+            } catch (e: Exception) {
+                errorMessage = e.message ?: "Failed to load events."
+                eventsGroupedByDate = emptyMap()
             } finally {
-
                 isLoadingEvents = false
-
             }
-
         }
-
     }
 
 
@@ -364,7 +359,8 @@ class CalendarViewModel(
 
     // Deletes google event
     suspend fun deleteGoogleEvent(event: CalendarEvent) {
-        val token = googleAccessToken ?: throw IllegalStateException("Not signed in to Google Calendar.")
+        val token = googleAccessToken
+            ?: throw IllegalStateException("Not signed in to Google Calendar.")
 
         if (event.source != CalendarSource.GOOGLE) {
             throw IllegalArgumentException("Only Google events can be deleted here.")
@@ -374,12 +370,18 @@ class CalendarViewModel(
             throw IllegalArgumentException("Missing Google event ID.")
         }
 
-        GoogleCalendarRepository.deleteEvent(
-            accessToken = token,
-            eventId = event.id
-        )
+        try {
+            GoogleCalendarRepository.deleteEvent(
+                accessToken = token,
+                eventId = event.id
+            )
 
-        loadEventsForCurrentWeek()
+            loadEventsForCurrentWeek()
+
+        } catch (e: GoogleCalendarUnauthorizedException) {
+            googleAccessToken = null
+            errorMessage = "Session expired. Please reconnect."
+            throw e
+        }
     }
-
 }


### PR DESCRIPTION
Fixed a 401 bug which essentially happened because when exiting app for too long the "persistent state" was relying on an old access token. Now it silently requests a new one so no matter how long you exit the app it should reconnect properly. 