### PR TITLE
Update UserListScreen

### DIFF
--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -22,19 +22,22 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.phinui.components.messages.User
 import com.example.phinui.ui.theme.*
-import com.example.phinui.viewmodel.UserListViewModel
 import androidx.compose.foundation.shape.CircleShape
-import kotlinx.coroutines.selects.select
+import com.example.phinui.data.friends.FriendRepository
+import com.example.phinui.viewmodel.FriendRepositoryViewModel
+import com.example.phinui.viewmodel.FriendRepositoryViewModelFactory
 
 
-@Composable fun UserListScreen (navController: NavController, viewModel: UserListViewModel = viewModel()) {
-    val users = viewModel.sortedUsers
-    val isLoadingStatus = viewModel.isLoading
+@Composable
+fun UserListScreen (
+    navController: NavController,
+    friendRepositoryViewModel: FriendRepositoryViewModel = viewModel(
+        factory = FriendRepositoryViewModelFactory(FriendRepository())
+)) {
+
+    val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
 
-    LaunchedEffect(Unit) {
-        viewModel.loadAllUsers()
-    }
 
     Column(modifier = Modifier
         .fillMaxSize()
@@ -59,38 +62,23 @@ import kotlinx.coroutines.selects.select
             //Friends tab
             0 -> {
                 Box {
-                    if (isLoadingStatus) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .wrapContentSize(Alignment.Center)
-                        ) {
-                            CircularProgressIndicator()
-                        }
-                    } else {
-                        LazyColumn(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(20.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            //item {
-                            //    Text(
-                            //        text = "Users",
-                            //        fontSize = 28.sp,
-                            //        fontWeight = FontWeight.SemiBold,
-                            //        color = NavText
-                            //    )
-                            //}
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(20.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        items(friendList) { friend ->
+                            val userID = friend.first
+                            val userName = friend.second
 
-                            //item {
-                            //    Spacer(modifier = Modifier.height(24.dp))
-                            //}
+                            val user = User(
+                                uid = userID,
+                                name = userName["name"] as? String?: "Unknown"
+                            )
 
-                            items(users) { user ->
-                                UserListItem(user = user, navController = navController)
-                                Spacer(modifier = Modifier.height(5.dp))
-                            }
+                            UserListItem(user = user, navController = navController)
+                            Spacer(modifier = Modifier.height(5.dp))
                         }
                     }
                 }

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -24,48 +24,75 @@ import com.example.phinui.components.messages.User
 import com.example.phinui.ui.theme.*
 import com.example.phinui.viewmodel.UserListViewModel
 import androidx.compose.foundation.shape.CircleShape
+import kotlinx.coroutines.selects.select
 
 
 @Composable fun UserListScreen (navController: NavController, viewModel: UserListViewModel = viewModel()) {
     val users = viewModel.sortedUsers
     val isLoadingStatus = viewModel.isLoading
+    var selectedTab by remember { mutableIntStateOf(value = 0) }
 
     LaunchedEffect(Unit) {
         viewModel.loadAllUsers()
     }
 
-    Box {
-        if (isLoadingStatus) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .wrapContentSize(Alignment.Center)
-            ) {
-                CircularProgressIndicator()
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        TabRow(selectedTabIndex = selectedTab) {
+            Tab(selected = selectedTab == 0,
+                onClick = {selectedTab = 0}) {
+                    Text("Friends")
             }
-        } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(20.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                item {
-                    Text(
-                        text = "Users",
-                        fontSize = 28.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        color = NavText
-                    )
-                }
+            Tab(selected = selectedTab == 1,
+                onClick = {selectedTab = 1}) {
+                    Text("Requests")
+            }
+        }
 
-                item {
-                    Spacer(modifier = Modifier.height(24.dp))
-                }
+        Spacer(modifier = Modifier.height(16.dp))
 
-                items(users) { user ->
-                    UserListItem(user = user, navController = navController)
-                    Spacer(modifier = Modifier.height(5.dp))
+        when(selectedTab) {
+
+            //Friends tab
+            0 -> {
+                Box {
+                    if (isLoadingStatus) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .wrapContentSize(Alignment.Center)
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(20.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            //item {
+                            //    Text(
+                            //        text = "Users",
+                            //        fontSize = 28.sp,
+                            //        fontWeight = FontWeight.SemiBold,
+                            //        color = NavText
+                            //    )
+                            //}
+
+                            //item {
+                            //    Spacer(modifier = Modifier.height(24.dp))
+                            //}
+
+                            items(users) { user ->
+                                UserListItem(user = user, navController = navController)
+                                Spacer(modifier = Modifier.height(5.dp))
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -69,15 +69,7 @@ fun UserListScreen (
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         items(friendList) { friend ->
-                            val userID = friend.first
-                            val userName = friend.second
-
-                            val user = User(
-                                uid = userID,
-                                name = userName["name"] as? String?: "Unknown"
-                            )
-
-                            UserListItem(user = user, navController = navController)
+                            UserListItem(user = friend, navController = navController)
                             Spacer(modifier = Modifier.height(5.dp))
                         }
                     }

--- a/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModel.kt
@@ -1,0 +1,29 @@
+package com.example.phinui.viewmodel
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.State
+import androidx.lifecycle.ViewModel
+import com.example.phinui.data.friends.FriendRepository
+
+class FriendRepositoryViewModel (private val friendRepository: FriendRepository) : ViewModel() {
+    private val _friendsList = mutableStateOf<List<Pair<String, Map<String, Any>>>>(emptyList())
+    val friendsList: State<List<Pair<String, Map<String, Any>>>> = _friendsList
+
+    private val _errorMessage = mutableStateOf<String?>(null)
+    val errorMessage: State<String?> = _errorMessage
+
+    init {
+        listenForFriendsUpdates()
+    }
+
+    private fun listenForFriendsUpdates() {
+        friendRepository.listenFriends(
+            onResult = { friends ->
+                _friendsList.value = friends
+            },
+            onError = { error ->
+                _errorMessage.value = "Error loading friends: ${error.message}"
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModel.kt
@@ -3,13 +3,11 @@ package com.example.phinui.viewmodel
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.State
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.example.phinui.components.messages.User
 import com.example.phinui.data.friends.FriendRepository
-import kotlinx.coroutines.launch
 
 class FriendRepositoryViewModel (private val friendRepository: FriendRepository) : ViewModel() {
-
+    
     private val _friendsList = mutableStateOf<List<User>>(emptyList())
     val friendsList: State<List<User>> = _friendsList
 
@@ -30,7 +28,7 @@ class FriendRepositoryViewModel (private val friendRepository: FriendRepository)
                         name = it.second["name"] as? String ?: "Unknown"
                     )
                 } .sortedBy { (it.name.lowercase() ) }
-                
+
                 _friendsList.value = alphabetizeFriendsList
 
             },

--- a/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModel.kt
@@ -3,11 +3,15 @@ package com.example.phinui.viewmodel
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.State
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.phinui.components.messages.User
 import com.example.phinui.data.friends.FriendRepository
+import kotlinx.coroutines.launch
 
 class FriendRepositoryViewModel (private val friendRepository: FriendRepository) : ViewModel() {
-    private val _friendsList = mutableStateOf<List<Pair<String, Map<String, Any>>>>(emptyList())
-    val friendsList: State<List<Pair<String, Map<String, Any>>>> = _friendsList
+
+    private val _friendsList = mutableStateOf<List<User>>(emptyList())
+    val friendsList: State<List<User>> = _friendsList
 
     private val _errorMessage = mutableStateOf<String?>(null)
     val errorMessage: State<String?> = _errorMessage
@@ -19,7 +23,16 @@ class FriendRepositoryViewModel (private val friendRepository: FriendRepository)
     private fun listenForFriendsUpdates() {
         friendRepository.listenFriends(
             onResult = { friends ->
-                _friendsList.value = friends
+
+                val alphabetizeFriendsList = friends.map {
+                    User(
+                        uid = it.first,
+                        name = it.second["name"] as? String ?: "Unknown"
+                    )
+                } .sortedBy { (it.name.lowercase() ) }
+                
+                _friendsList.value = alphabetizeFriendsList
+
             },
             onError = { error ->
                 _errorMessage.value = "Error loading friends: ${error.message}"

--- a/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModelFactory.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/FriendRepositoryViewModelFactory.kt
@@ -1,0 +1,14 @@
+package com.example.phinui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.phinui.data.friends.FriendRepository
+
+class FriendRepositoryViewModelFactory(private val friendRepository: FriendRepository) : ViewModelProvider.Factory {
+    override fun <T: ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(FriendRepositoryViewModel::class.java)) {
+            return FriendRepositoryViewModel(friendRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
- UserListScreen now shows a "Friends" tab and a "Requests" tab
- The "Friends" tab should only show messages with users that are in your friends list
- The "Requests" tab is empty/non-functional at this time. Will be updated in a future pull request.
- Created a FriendRepositoryViewModel and a FriendRepositoryViewModelFactory for displaying the friend list in the UserListScreen