### PR TITLE
Messaging - Sending requests

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -34,9 +34,7 @@ class ChatRepository {
                 "lastMessage" to messageText,
                 "lastTimestamp" to messageProperties.currentTime,
                 "participants" to listOf(senderUserID, receiverUserID),
-                //ADDED 4/11
                 "messageRequestApproved" to true
-                //END OF ADDED
             )
         //Default info if chat between users doesn't exist yet
         ).addOnFailureListener {
@@ -45,16 +43,13 @@ class ChatRepository {
                     "lastMessage" to messageText,
                     "lastTimestamp" to messageProperties.currentTime,
                     "participants" to listOf(senderUserID, receiverUserID),
-                    //ADDED 4/11
                     "messageRequestApproved" to true
-                    //END OF ADDED
                 )
             )
         }
     }
 
-    //ADDED 4/11
-    fun sendMessageRequest(senderUserID: String, receiverUserID: String, messageText: String) {
+    fun sendMessageRequest(senderUserID: String, receiverUserID: String) {
         val messageProperties = messageInfoHelper(senderUserID, receiverUserID)
 
         messageProperties.chatReference.update(
@@ -85,7 +80,6 @@ class ChatRepository {
         chatsCollection.document(chatID)
             .delete()
     }
-    //END OF ADDED
 
     fun checkForNewMessage(senderUserID: String, receiverUserID: String, newMessage: (List<Map<String, Any>>) -> Unit) {
         val messageProperties = messageInfoHelper(senderUserID, receiverUserID)
@@ -100,7 +94,6 @@ class ChatRepository {
             }
     }
 
-    //ADDED 4/11
     fun listenMessageRequest(
         userID: String,
         onResult: (List<Map<String, Any>>) -> Unit
@@ -110,7 +103,6 @@ class ChatRepository {
             .whereEqualTo("messageRequestApproved", false)
             .addSnapshotListener { snapshot, error ->
                 if (error != null || snapshot == null) return@addSnapshotListener
-                //val messageRequest = snapshot.documents.mapNotNull { it.data }
                 val messageRequest = snapshot.documents.mapNotNull { doc ->
                     val data = doc.data ?: return@mapNotNull null
                     data + mapOf("chatID" to doc.id)
@@ -128,7 +120,6 @@ class ChatRepository {
             .whereEqualTo("messageRequestApproved", true)
             .addSnapshotListener { snapshot, error ->
                 if (error != null || snapshot == null) return@addSnapshotListener
-                //val chats = snapshot.documents.mapNotNull { it.data }
                 val chats = snapshot.documents.mapNotNull { doc ->
                     val data = doc.data ?: return@mapNotNull null
                     data + mapOf("chatID" to doc.id)
@@ -137,7 +128,6 @@ class ChatRepository {
             }
     }
 
-    //END OF ADDED
     data class MessageInfo(
         val chatID: String,
         val chatReference: DocumentReference,

--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -80,6 +80,11 @@ class ChatRepository {
         chatsCollection.document(chatID)
             .update("messageRequestApproved", true)
     }
+
+    fun denyMessageRequest(chatID: String) {
+        chatsCollection.document(chatID)
+            .delete()
+    }
     //END OF ADDED
 
     fun checkForNewMessage(senderUserID: String, receiverUserID: String, newMessage: (List<Map<String, Any>>) -> Unit) {
@@ -105,7 +110,11 @@ class ChatRepository {
             .whereEqualTo("messageRequestApproved", false)
             .addSnapshotListener { snapshot, error ->
                 if (error != null || snapshot == null) return@addSnapshotListener
-                val messageRequest = snapshot.documents.mapNotNull { it.data }
+                //val messageRequest = snapshot.documents.mapNotNull { it.data }
+                val messageRequest = snapshot.documents.mapNotNull { doc ->
+                    val data = doc.data ?: return@mapNotNull null
+                    data + mapOf("chatID" to doc.id)
+                }
                 onResult(messageRequest)
             }
     }
@@ -119,7 +128,11 @@ class ChatRepository {
             .whereEqualTo("messageRequestApproved", true)
             .addSnapshotListener { snapshot, error ->
                 if (error != null || snapshot == null) return@addSnapshotListener
-                val chats = snapshot.documents.mapNotNull { it.data }
+                //val chats = snapshot.documents.mapNotNull { it.data }
+                val chats = snapshot.documents.mapNotNull { doc ->
+                    val data = doc.data ?: return@mapNotNull null
+                    data + mapOf("chatID" to doc.id)
+                }
                 onResult(chats)
             }
     }

--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -33,7 +33,10 @@ class ChatRepository {
             mapOf(
                 "lastMessage" to messageText,
                 "lastTimestamp" to messageProperties.currentTime,
-                "participants" to listOf(senderUserID, receiverUserID)
+                "participants" to listOf(senderUserID, receiverUserID),
+                //ADDED 4/11
+                "messageRequestApproved" to true
+                //END OF ADDED
             )
         //Default info if chat between users doesn't exist yet
         ).addOnFailureListener {
@@ -41,11 +44,43 @@ class ChatRepository {
                 mapOf(
                     "lastMessage" to messageText,
                     "lastTimestamp" to messageProperties.currentTime,
-                    "participants" to listOf(senderUserID, receiverUserID)
+                    "participants" to listOf(senderUserID, receiverUserID),
+                    //ADDED 4/11
+                    "messageRequestApproved" to true
+                    //END OF ADDED
                 )
             )
         }
     }
+
+    //ADDED 4/11
+    fun sendMessageRequest(senderUserID: String, receiverUserID: String, messageText: String) {
+        val messageProperties = messageInfoHelper(senderUserID, receiverUserID)
+
+        messageProperties.chatReference.update(
+            mapOf(
+                "lastMessage" to "",
+                "lastTimestamp" to messageProperties.currentTime,
+                "participants" to listOf(senderUserID, receiverUserID),
+                "messageRequestApproved" to false
+            )
+        ).addOnFailureListener {
+            messageProperties.chatReference.set(
+                mapOf(
+                    "lastMessage" to "",
+                    "lastTimestamp" to messageProperties.currentTime,
+                    "participants" to listOf(senderUserID, receiverUserID),
+                    "messageRequestApproved" to false
+                )
+            )
+        }
+    }
+
+    fun approveMessageRequest(chatID: String) {
+        chatsCollection.document(chatID)
+            .update("messageRequestApproved", true)
+    }
+    //END OF ADDED
 
     fun checkForNewMessage(senderUserID: String, receiverUserID: String, newMessage: (List<Map<String, Any>>) -> Unit) {
         val messageProperties = messageInfoHelper(senderUserID, receiverUserID)
@@ -60,6 +95,36 @@ class ChatRepository {
             }
     }
 
+    //ADDED 4/11
+    fun listenMessageRequest(
+        userID: String,
+        onResult: (List<Map<String, Any>>) -> Unit
+    ) {
+        chatsCollection
+            .whereArrayContains("participants", userID)
+            .whereEqualTo("messageRequestApproved", false)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null || snapshot == null) return@addSnapshotListener
+                val messageRequest = snapshot.documents.mapNotNull { it.data }
+                onResult(messageRequest)
+            }
+    }
+
+    fun listenChats(
+        userID: String,
+        onResult: (List<Map<String, Any>>) -> Unit
+    ) {
+        chatsCollection
+            .whereArrayContains("participants", userID)
+            .whereEqualTo("messageRequestApproved", true)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null || snapshot == null) return@addSnapshotListener
+                val chats = snapshot.documents.mapNotNull { it.data }
+                onResult(chats)
+            }
+    }
+
+    //END OF ADDED
     data class MessageInfo(
         val chatID: String,
         val chatReference: DocumentReference,

--- a/app/src/main/java/com/example/phinui/components/messages/UserListRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/UserListRepository.kt
@@ -42,4 +42,26 @@ class UserListRepository {
             null
         }
     }
+
+    fun getUserNameByID(
+        userID: String,
+        onResult: (User) -> Unit,
+        onError: (Exception) -> Unit
+    ) {
+
+        database.collection("users")
+            .document(userID)
+            .get()
+            .addOnSuccessListener { document ->
+                if (document.exists()) {
+                    val userName = document.getString("name") ?: "Unknown User"
+                    val user = User(uid = userID, name = userName)
+                    onResult(user)
+            } else {
+                onError(Exception("User not found"))
+                }
+        }.addOnFailureListener { exception ->
+            onError(exception)
+            }
+    }
 }

--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.phinui.components.messages.ChatRepository
 import com.example.phinui.ui.theme.*
+import com.example.phinui.viewmodel.ChatRepositoryViewModel
 import com.example.phinui.viewmodel.UserListViewModel
 
 
@@ -29,16 +30,22 @@ import com.example.phinui.viewmodel.UserListViewModel
 fun MessagesScreen(
     senderUserID: String,
     receiverUserID: String,
-    viewModel: UserListViewModel = viewModel(),
+    userListViewModel: UserListViewModel = viewModel(),
+    chatRepositoryViewModel: ChatRepositoryViewModel = viewModel(),
     setTopBarTitle: (String) -> Unit
 ) {
     val chatRepository = remember { ChatRepository() }
     var messageText by remember { mutableStateOf("") }
     var messages by remember { mutableStateOf(listOf<Map<String, Any>>()) }
-    val selectedUser = viewModel.selectedUser
-    val isLoadingStatus = viewModel.isLoading
+    val selectedUser = userListViewModel.selectedUser
+    val isLoadingStatus = userListViewModel.isLoading
     val autoScrollState = rememberLazyListState()
     val initialChatOpen = remember { mutableStateOf(true) }
+
+    //ADDED 4/11
+    val approvedChats = chatRepositoryViewModel.approvedChats.value
+    val messageRequests = chatRepositoryViewModel.messageRequests.value
+    //END OF ADDED
 
     LaunchedEffect(selectedUser) {
         selectedUser?.name?.let { userName ->
@@ -53,7 +60,7 @@ fun MessagesScreen(
     }
 
     LaunchedEffect(receiverUserID) {
-        viewModel.loadSelectedUser(receiverUserID)
+        userListViewModel.loadSelectedUser(receiverUserID)
     }
 
     if (initialChatOpen.value) {

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -285,8 +285,8 @@ fun PeopleScreen() {
                                                 senderID,
                                                 uid,
                                             )
-                                            chatRepositoryViewModel.loadMessageRequest(senderID)
-                                            chatRepositoryViewModel.loadMessageRequest(uid)
+                                            //chatRepositoryViewModel.loadMessageRequest(senderID)
+                                            //chatRepositoryViewModel.loadMessageRequest(uid)
                                             showMenu = false
                                         }
                                     )

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -191,6 +191,10 @@ fun PeopleScreen() {
                                             //{ message = "Request sent" },
                                             //{ message = it.message }
                                         )
+                                        //ADDED 4/13
+                                        chatRepositoryViewModel.loadMessageRequest(senderID)
+                                        chatRepositoryViewModel.loadMessageRequest(uid)
+                                        //END OF ADDE
                                     }
                                 ) {
                                     Icon(

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -32,7 +32,10 @@ import com.google.firebase.firestore.ListenerRegistration
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Email
 import androidx.compose.material3.IconButton
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.phinui.viewmodel.ChatRepositoryViewModel
 
 @Composable
 fun PeopleScreen() {
@@ -49,6 +52,7 @@ fun PeopleScreen() {
     var blockedUsers by remember { mutableStateOf<List<Pair<String, Map<String, Any>>>>(emptyList()) }
     var message by remember { mutableStateOf<String?>(null) }
     var myName by remember { mutableStateOf("") }
+    val chatRepositoryViewModel: ChatRepositoryViewModel = viewModel()
 
     LaunchedEffect(Unit) {
         val uid = auth.currentUser?.uid ?: return@LaunchedEffect
@@ -172,6 +176,26 @@ fun PeopleScreen() {
                                     Icon(
                                         imageVector = Icons.Default.Add,
                                         contentDescription = "Add Friend",
+                                        tint = HeaderRed
+                                    )
+                                }
+
+                                Spacer(modifier = Modifier.width(4.dp))
+
+                                IconButton(
+                                    onClick = {
+                                        val senderID = chatRepositoryViewModel.currentUserID ?: return@IconButton
+                                        chatRepositoryViewModel.sendMessageRequest(
+                                            senderID,
+                                            uid,
+                                            //{ message = "Request sent" },
+                                            //{ message = it.message }
+                                        )
+                                    }
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Email,
+                                        contentDescription = "Send Message Request",
                                         tint = HeaderRed
                                     )
                                 }

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -24,6 +25,7 @@ import com.example.phinui.components.messages.User
 import com.example.phinui.ui.theme.*
 import androidx.compose.foundation.shape.CircleShape
 import com.example.phinui.data.friends.FriendRepository
+import com.example.phinui.viewmodel.ChatRepositoryViewModel
 import com.example.phinui.viewmodel.FriendRepositoryViewModel
 import com.example.phinui.viewmodel.FriendRepositoryViewModelFactory
 import com.example.phinui.viewmodel.UserListViewModel
@@ -34,6 +36,7 @@ fun UserListScreen (
     navController: NavController,
     //ADDED 4/11
     //userListViewModel: UserListViewModel = viewModel(),
+    chatRepositoryViewModel: ChatRepositoryViewModel = viewModel(),
     //END OF ADDED
     friendRepositoryViewModel: FriendRepositoryViewModel = viewModel(
         factory = FriendRepositoryViewModelFactory(FriendRepository())
@@ -42,6 +45,8 @@ fun UserListScreen (
     //ADDED 4/11
     //val users = userListViewModel.sortedUsers
     //val isLoadingStatus = userListViewModel.isLoading
+    val messageRequest = chatRepositoryViewModel.messageRequests
+    val currentUserID = chatRepositoryViewModel.currentUserID ?: return
     //END OF ADDED
     val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
@@ -64,6 +69,10 @@ fun UserListScreen (
             }
             Tab(selected = selectedTab == 1,
                 onClick = {selectedTab = 1}) {
+                Text("General")
+            }
+            Tab(selected = selectedTab == 2,
+                onClick = {selectedTab = 2}) {
                     Text("Requests")
             }
         }
@@ -82,17 +91,99 @@ fun UserListScreen (
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         items(friendList) { friend ->
-                            UserListItem(user = friend, navController = navController)
+                            //UserListItem(user = friend, navController = navController)
+                            //ADDED 4/11
+                            UserListItem(
+                                user = friend,
+                                onClick = {
+                                    navController.navigate(Routes.MESSAGES + "/${friend.uid}")
+                                }
+                            )
+                            //END OF ADDED
                             Spacer(modifier = Modifier.height(5.dp))
                         }
                     }
                 }
             }
+
+            //ADDED 4/11
+            //General tab
+
+            //Requests tab
+            2 -> {
+                Box {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(20.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        items(messageRequest.value) { chat ->
+                            val chatID = chat["chatID"] as? String ?: return@items
+                            val participants = chat["participants"] as? List<*> ?: return@items
+
+                            val otherUserID = participants
+                                .mapNotNull { it as? String }
+                                .firstOrNull{ it != currentUserID } ?:return@items
+
+                            val user = User(
+                                uid = otherUserID,
+                                name = otherUserID
+                            )
+//                            Row(
+//                                modifier = Modifier.fillMaxWidth(),
+//                                horizontalArrangement = Arrangement.SpaceBetween
+//                            ) {
+//                                Text("Message Request")
+//                                Row{
+//                                    Button(onClick = {
+//                                        chatRepositoryViewModel.approveRequest(chatID)
+//                                    })
+//                                    Text("Accept")
+//                                }
+//
+//                                Button(onClick = {
+//                                    chatRepositoryViewModel.denyRequest(chatID)
+//                                })
+//                                Text("Decline")
+//                            }
+                            //UserListItem(user = friend, navController = navController)
+                            UserListItem(
+                                user = user,
+                                trailingContent = {
+                                    Row{
+                                        Button(onClick = {
+                                            chatRepositoryViewModel.approveRequest(chatID)
+                                        }) {
+                                            Text("Accept")
+                                        }
+
+                                        Spacer(modifier = Modifier.width(8.dp))
+
+                                        Button(onClick = {
+                                            chatRepositoryViewModel.denyRequest(chatID)
+                                        }) {
+                                            Text("Decline")
+                                        }
+                                    }
+                                }
+                                )
+                            Spacer(modifier = Modifier.height(5.dp))
+                        }
+                    }
+                }
+            }
+            //END OF ADDED
         }
     }
 }
 
-@Composable fun UserListItem(user: User, navController: NavController) {
+//ADDED 4/11
+@Composable fun UserListItem(
+    user: User,
+    trailingContent: @Composable (() -> Unit)? = null,
+    onClick:(() -> Unit)? = null
+) {
     val initial = user.name
         .trim()
         .firstOrNull()
@@ -101,9 +192,12 @@ fun UserListScreen (
         modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp)
-            .clickable{
-                navController.navigate(Routes.MESSAGES + "/${user.uid}")
-            }
+            .then(
+                if (onClick != null) Modifier.clickable {
+                    onClick()
+                }
+                else Modifier
+            )
             .shadow(
                 elevation = 4.dp,
                 shape = RoundedCornerShape(12.dp)
@@ -115,37 +209,100 @@ fun UserListScreen (
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
 
         ) {
             // User Icons
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(CircleShape)
-                    .background(Color(0xFFFFEFEF)),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = initial,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color(0xFFD32F2F),
-                    fontWeight = FontWeight.SemiBold
-                )
-            }
-
-            Spacer(modifier = Modifier.width(16.dp))
-
-            Column {
-                Text(
-                    text = user.name,
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 18.sp,
-                        color = TextMuted
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFFFEFEF)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = initial,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = Color(0xFFD32F2F),
+                        fontWeight = FontWeight.SemiBold
                     )
-                )
+                }
+
+                Spacer(modifier = Modifier.width(16.dp))
+
+                //Column {
+                    Text(
+                        text = user.name,
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 18.sp,
+                            color = TextMuted
+                        )
+                    )
+                //}
             }
+            trailingContent?.invoke()
         }
     }
 }
+//END OF ADDED
+
+//@Composable fun UserListItem(user: User, navController: NavController) {
+//    val initial = user.name
+//        .trim()
+//        .firstOrNull()
+//        ?.uppercase() ?: "?"
+//    Surface(
+//        modifier = Modifier
+//            .fillMaxWidth()
+//            .padding(16.dp)
+//            .clickable{
+//                navController.navigate(Routes.MESSAGES + "/${user.uid}")
+//            }
+//            .shadow(
+//                elevation = 4.dp,
+//                shape = RoundedCornerShape(12.dp)
+//            ),
+//        shape = RoundedCornerShape(12.dp),
+//        color = Color.White
+//    ) {
+//        Row(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .padding(16.dp),
+//            verticalAlignment = Alignment.CenterVertically
+//
+//        ) {
+//            // User Icons
+//            Box(
+//                modifier = Modifier
+//                    .size(40.dp)
+//                    .clip(CircleShape)
+//                    .background(Color(0xFFFFEFEF)),
+//                contentAlignment = Alignment.Center
+//            ) {
+//                Text(
+//                    text = initial,
+//                    style = MaterialTheme.typography.titleMedium,
+//                    color = Color(0xFFD32F2F),
+//                    fontWeight = FontWeight.SemiBold
+//                )
+//            }
+//
+//            Spacer(modifier = Modifier.width(16.dp))
+//
+//            Column {
+//                Text(
+//                    text = user.name,
+//                    style = MaterialTheme.typography.bodyLarge.copy(
+//                        fontWeight = FontWeight.SemiBold,
+//                        fontSize = 18.sp,
+//                        color = TextMuted
+//                    )
+//                )
+//            }
+//        }
+//    }
+//}

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -45,6 +45,11 @@ fun UserListScreen (
     val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
 
+    //ADDED 4/13
+    LaunchedEffect(currentUserID){
+        chatRepositoryViewModel.loadMessageRequest(currentUserID)
+    }
+    //END OF ADDED
     Column(modifier = Modifier
         .fillMaxSize()
         .padding(20.dp),
@@ -95,19 +100,30 @@ fun UserListScreen (
 
             //Requests tab
             2 -> {
+                //ADDED 4/13
+                var messageRequestState by remember { mutableStateOf<List<Map<String, Any>>>(emptyList()) }
+                LaunchedEffect(currentUserID){
+                    chatRepositoryViewModel.loadMessageRequest(currentUserID)
+                }
+
+                LaunchedEffect(messageRequestState) {
+                    messageRequestState = chatRepositoryViewModel.messageRequests.value
+                }
+                //END OF ADDED
                 Box {
-                    LaunchedEffect(Unit) {
-                        val uid = chatRepositoryViewModel.currentUserID ?: return@LaunchedEffect
-                        chatRepositoryViewModel.loadMessageRequest(uid)
-                    }
+                    //LaunchedEffect(Unit) {
+                    //    val uid = chatRepositoryViewModel.currentUserID ?: return@LaunchedEffect
+                    //    chatRepositoryViewModel.loadMessageRequest(uid)
+                    //}
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(20.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        items(messageRequest.value) { chat ->
-                            val chatID = chat["chatID"] as? String ?: return@items
+                        //items(messageRequest.value) { chat ->
+                        items(messageRequestState) { chat ->
+                        val chatID = chat["chatID"] as? String ?: return@items
                             val participants = chat["participants"] as? List<*> ?: return@items
 
                             val otherUserID = participants

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -26,18 +26,31 @@ import androidx.compose.foundation.shape.CircleShape
 import com.example.phinui.data.friends.FriendRepository
 import com.example.phinui.viewmodel.FriendRepositoryViewModel
 import com.example.phinui.viewmodel.FriendRepositoryViewModelFactory
+import com.example.phinui.viewmodel.UserListViewModel
 
 
 @Composable
 fun UserListScreen (
     navController: NavController,
+    //ADDED 4/11
+    //userListViewModel: UserListViewModel = viewModel(),
+    //END OF ADDED
     friendRepositoryViewModel: FriendRepositoryViewModel = viewModel(
         factory = FriendRepositoryViewModelFactory(FriendRepository())
 )) {
 
+    //ADDED 4/11
+    //val users = userListViewModel.sortedUsers
+    //val isLoadingStatus = userListViewModel.isLoading
+    //END OF ADDED
     val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
 
+    //ADDED 4/11
+    //LaunchedEffect(Unit) {
+    //    userListViewModel.loadAllUsers()
+   //}
+    //END OF ADDED
 
     Column(modifier = Modifier
         .fillMaxSize()

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.phinui.components.messages.User
 import com.example.phinui.ui.theme.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.lifecycle.viewModelScope
 import com.example.phinui.data.friends.FriendRepository
 import com.example.phinui.viewmodel.ChatRepositoryViewModel
 import com.example.phinui.viewmodel.FriendRepositoryViewModel
@@ -34,28 +35,15 @@ import com.example.phinui.viewmodel.UserListViewModel
 @Composable
 fun UserListScreen (
     navController: NavController,
-    //ADDED 4/11
-    //userListViewModel: UserListViewModel = viewModel(),
     chatRepositoryViewModel: ChatRepositoryViewModel = viewModel(),
-    //END OF ADDED
     friendRepositoryViewModel: FriendRepositoryViewModel = viewModel(
         factory = FriendRepositoryViewModelFactory(FriendRepository())
-)) {
+    )) {
 
-    //ADDED 4/11
-    //val users = userListViewModel.sortedUsers
-    //val isLoadingStatus = userListViewModel.isLoading
     val messageRequest = chatRepositoryViewModel.messageRequests
     val currentUserID = chatRepositoryViewModel.currentUserID ?: return
-    //END OF ADDED
     val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
-
-    //ADDED 4/11
-    //LaunchedEffect(Unit) {
-    //    userListViewModel.loadAllUsers()
-   //}
-    //END OF ADDED
 
     Column(modifier = Modifier
         .fillMaxSize()
@@ -65,7 +53,7 @@ fun UserListScreen (
         TabRow(selectedTabIndex = selectedTab) {
             Tab(selected = selectedTab == 0,
                 onClick = {selectedTab = 0}) {
-                    Text("Friends")
+                Text("Friends")
             }
             Tab(selected = selectedTab == 1,
                 onClick = {selectedTab = 1}) {
@@ -73,7 +61,7 @@ fun UserListScreen (
             }
             Tab(selected = selectedTab == 2,
                 onClick = {selectedTab = 2}) {
-                    Text("Requests")
+                Text("Requests")
             }
         }
 
@@ -91,27 +79,27 @@ fun UserListScreen (
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         items(friendList) { friend ->
-                            //UserListItem(user = friend, navController = navController)
-                            //ADDED 4/11
                             UserListItem(
                                 user = friend,
                                 onClick = {
                                     navController.navigate(Routes.MESSAGES + "/${friend.uid}")
                                 }
                             )
-                            //END OF ADDED
                             Spacer(modifier = Modifier.height(5.dp))
                         }
                     }
                 }
             }
 
-            //ADDED 4/11
             //General tab
 
             //Requests tab
             2 -> {
                 Box {
+                    LaunchedEffect(Unit) {
+                        val uid = chatRepositoryViewModel.currentUserID ?: return@LaunchedEffect
+                        chatRepositoryViewModel.loadMessageRequest(uid)
+                    }
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxSize()
@@ -126,28 +114,25 @@ fun UserListScreen (
                                 .mapNotNull { it as? String }
                                 .firstOrNull{ it != currentUserID } ?:return@items
 
+                            var userName by remember { mutableStateOf("Loading...")}
+
+                            LaunchedEffect(otherUserID) {
+                                chatRepositoryViewModel.userListRepository.getUserNameByID(
+                                    otherUserID,
+                                    onResult = { user ->
+                                        userName = user.name
+                                    },
+                                    onError = {exception ->
+                                        userName = "Unknown User"
+                                    }
+                                )
+                            }
+
                             val user = User(
                                 uid = otherUserID,
-                                name = otherUserID
+                                name = userName
                             )
-//                            Row(
-//                                modifier = Modifier.fillMaxWidth(),
-//                                horizontalArrangement = Arrangement.SpaceBetween
-//                            ) {
-//                                Text("Message Request")
-//                                Row{
-//                                    Button(onClick = {
-//                                        chatRepositoryViewModel.approveRequest(chatID)
-//                                    })
-//                                    Text("Accept")
-//                                }
-//
-//                                Button(onClick = {
-//                                    chatRepositoryViewModel.denyRequest(chatID)
-//                                })
-//                                Text("Decline")
-//                            }
-                            //UserListItem(user = friend, navController = navController)
+
                             UserListItem(
                                 user = user,
                                 trailingContent = {
@@ -167,18 +152,16 @@ fun UserListScreen (
                                         }
                                     }
                                 }
-                                )
+                            )
                             Spacer(modifier = Modifier.height(5.dp))
                         }
                     }
                 }
             }
-            //END OF ADDED
         }
     }
 }
 
-//ADDED 4/11
 @Composable fun UserListItem(
     user: User,
     trailingContent: @Composable (() -> Unit)? = null,
@@ -232,77 +215,16 @@ fun UserListScreen (
 
                 Spacer(modifier = Modifier.width(16.dp))
 
-                //Column {
-                    Text(
-                        text = user.name,
-                        style = MaterialTheme.typography.bodyLarge.copy(
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 18.sp,
-                            color = TextMuted
-                        )
+                Text(
+                    text = user.name,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 18.sp,
+                        color = TextMuted
                     )
-                //}
+                )
             }
             trailingContent?.invoke()
         }
     }
 }
-//END OF ADDED
-
-//@Composable fun UserListItem(user: User, navController: NavController) {
-//    val initial = user.name
-//        .trim()
-//        .firstOrNull()
-//        ?.uppercase() ?: "?"
-//    Surface(
-//        modifier = Modifier
-//            .fillMaxWidth()
-//            .padding(16.dp)
-//            .clickable{
-//                navController.navigate(Routes.MESSAGES + "/${user.uid}")
-//            }
-//            .shadow(
-//                elevation = 4.dp,
-//                shape = RoundedCornerShape(12.dp)
-//            ),
-//        shape = RoundedCornerShape(12.dp),
-//        color = Color.White
-//    ) {
-//        Row(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .padding(16.dp),
-//            verticalAlignment = Alignment.CenterVertically
-//
-//        ) {
-//            // User Icons
-//            Box(
-//                modifier = Modifier
-//                    .size(40.dp)
-//                    .clip(CircleShape)
-//                    .background(Color(0xFFFFEFEF)),
-//                contentAlignment = Alignment.Center
-//            ) {
-//                Text(
-//                    text = initial,
-//                    style = MaterialTheme.typography.titleMedium,
-//                    color = Color(0xFFD32F2F),
-//                    fontWeight = FontWeight.SemiBold
-//                )
-//            }
-//
-//            Spacer(modifier = Modifier.width(16.dp))
-//
-//            Column {
-//                Text(
-//                    text = user.name,
-//                    style = MaterialTheme.typography.bodyLarge.copy(
-//                        fontWeight = FontWeight.SemiBold,
-//                        fontSize = 18.sp,
-//                        color = TextMuted
-//                    )
-//                )
-//            }
-//        }
-//    }
-//}

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -1,0 +1,25 @@
+package com.example.phinui.viewmodel
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.example.phinui.components.messages.ChatRepository
+
+class ChatRepositoryViewModel (
+    private val chatRepository: ChatRepository = ChatRepository()
+) : ViewModel() {
+
+    val approvedChats = mutableStateOf<List<Map<String, Any>>>(emptyList())
+    val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
+
+    fun loadApprovedChats(userID: String) {
+        chatRepository.listenChats(userID) {
+            approvedChats.value = it
+        }
+    }
+
+    fun loadMessageRequest(userID: String) {
+        chatRepository.listenMessageRequest(userID) {
+            messageRequests.value = it
+        }
+    }
+}

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -2,16 +2,28 @@ package com.example.phinui.viewmodel
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.phinui.components.messages.ChatRepository
+import com.example.phinui.components.messages.User
+import com.example.phinui.components.messages.UserListRepository
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class ChatRepositoryViewModel (
-    private val chatRepository: ChatRepository = ChatRepository()
+    private val chatRepository: ChatRepository = ChatRepository(),
+    val userListRepository: UserListRepository = UserListRepository()
 ) : ViewModel() {
 
-    val currentUserID = FirebaseAuth.getInstance().currentUser?.uid
+    val firebaseAuthenticated = FirebaseAuth.getInstance()
+    val firebaseFirestoreAuthenticated = FirebaseFirestore.getInstance()
+    val currentUserID = firebaseAuthenticated.currentUser?.uid
+    //val currentUserID = FirebaseAuth.getInstance().currentUser?.uid
     val approvedChats = mutableStateOf<List<Map<String, Any>>>(emptyList())
     val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
+
+    //val requestUsers = mutableStateOf<List<User>>(emptyList())
 
     fun loadApprovedChats(userID: String) {
         chatRepository.listenChats(userID) {
@@ -25,6 +37,35 @@ class ChatRepositoryViewModel (
         }
     }
 
+//    fun loadRequestUsers(currentUserID: String) {
+//        chatRepository.listenMessageRequest(currentUserID) { chats ->
+//            viewModelScope.launch {
+//                //val users = chats.mapNotNull { chat ->
+//                val users = mutableListOf<User>()
+//                for (chat in chats) {
+//                    val participants =
+//                        //chat["participants"] as? List<String> ?: return@mapNotNull null
+//                        chat["participants"] as? List<String> ?: continue
+//
+//                    val otherUserID =
+//                        //participants.firstOrNull { it != currentUserID } ?: return@mapNotNull null
+//                        participants.firstOrNull { it != currentUserID } ?: continue
+//                    //getUserNameByID(otherUserID)
+//                    userListRepository.getUserNameByID(otherUserID, { user ->
+//                        users.add(user)
+//                    }, { exception ->
+//                        println("Error fetching user: ${exception.message}")
+//                    })
+//                    requestUsers.value = users
+//                }
+//            }
+//        }
+//    }
+
+    fun sendMessageRequest(senderUserID: String, receiverUserID: String) {
+        chatRepository.sendMessageRequest(senderUserID, receiverUserID)
+    }
+
     fun approveRequest(chatID: String) {
         chatRepository.approveMessageRequest(chatID)
     }
@@ -32,4 +73,24 @@ class ChatRepositoryViewModel (
     fun denyRequest(chatID: String) {
         chatRepository.denyMessageRequest(chatID)
     }
+
+//    fun getUserNameByID(
+//        userID: String,
+//        onResult: (User) -> Unit,
+//        onError: (Exception) -> Unit) {
+//
+//        firebaseFirestoreAuthenticated.collection("users").document(userID)
+//            .get()
+//            .addOnSuccessListener { document ->
+//                if (document.exists()) {
+//                    val userName = document.getString("name") ?: "Unknown User"
+//                    val user = User(uid = userID, name = userName)
+//                    onResult(user)
+//            } else {
+//                onError(Exception("User not found"))
+//                }
+//        }.addOnFailureListener { exception ->
+//            onError(exception)
+//            }
+//    }
 }

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -3,11 +3,13 @@ package com.example.phinui.viewmodel
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import com.example.phinui.components.messages.ChatRepository
+import com.google.firebase.auth.FirebaseAuth
 
 class ChatRepositoryViewModel (
     private val chatRepository: ChatRepository = ChatRepository()
 ) : ViewModel() {
 
+    val currentUserID = FirebaseAuth.getInstance().currentUser?.uid
     val approvedChats = mutableStateOf<List<Map<String, Any>>>(emptyList())
     val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
 
@@ -21,5 +23,13 @@ class ChatRepositoryViewModel (
         chatRepository.listenMessageRequest(userID) {
             messageRequests.value = it
         }
+    }
+
+    fun approveRequest(chatID: String) {
+        chatRepository.approveMessageRequest(chatID)
+    }
+
+    fun denyRequest(chatID: String) {
+        chatRepository.denyMessageRequest(chatID)
     }
 }


### PR DESCRIPTION
- Users can now send a message request
- Receiving user will see the request under "Requests" on the UserListScreen (aka Messages)
- The UserListScreen (Messages screen) has 3 tabs listed as "Friends" "General" "Requests"
- The accept button does not work at the moment

To Do:
- Adjust the accept and deny buttons so they are both visible
- Possibly change the buttons to icons
- Make the accept button move the chat to the "General" tab
- Remove the message request if the user denies the request