### PR TITLE
Messaging - Accepting or denying requests

### DIFF
--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -31,7 +31,7 @@ fun MessagesScreen(
     senderUserID: String,
     receiverUserID: String,
     userListViewModel: UserListViewModel = viewModel(),
-    chatRepositoryViewModel: ChatRepositoryViewModel = viewModel(),
+    //chatRepositoryViewModel: ChatRepositoryViewModel = viewModel(),
     setTopBarTitle: (String) -> Unit
 ) {
     val chatRepository = remember { ChatRepository() }
@@ -41,11 +41,6 @@ fun MessagesScreen(
     val isLoadingStatus = userListViewModel.isLoading
     val autoScrollState = rememberLazyListState()
     val initialChatOpen = remember { mutableStateOf(true) }
-
-    //ADDED 4/11
-    val approvedChats = chatRepositoryViewModel.approvedChats.value
-    val messageRequests = chatRepositoryViewModel.messageRequests.value
-    //END OF ADDED
 
     LaunchedEffect(selectedUser) {
         selectedUser?.name?.let { userName ->

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -1,5 +1,6 @@
 package com.example.phinui.ui.screens
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -58,11 +59,8 @@ import com.example.phinui.ui.theme.TextMuted
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Email
-import androidx.compose.material3.IconButton
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.phinui.viewmodel.ChatRepositoryViewModel
 
@@ -94,6 +92,11 @@ fun PeopleScreen() {
             .addOnSuccessListener {
                 myName = it.getString("name") ?: ""
             }
+    }
+
+    LaunchedEffect(Unit) {
+        val currentUserID = auth.currentUser?.uid ?: return@LaunchedEffect
+        chatRepositoryViewModel.startListening(userID = currentUserID)
     }
 
     DisposableEffect(Unit) {
@@ -284,6 +287,7 @@ fun PeopleScreen() {
                                             chatRepositoryViewModel.sendMessageRequest(
                                                 senderID,
                                                 uid,
+                                                name
                                             )
                                             showMenu = false
                                         }
@@ -541,5 +545,39 @@ fun PeopleScreen() {
                 }
             }
         )
+    }
+
+    val receiverUserName = chatRepositoryViewModel.activeChatUserName.value ?: "Unknown"
+    if (chatRepositoryViewModel.showMessageApprovedDialog.value) {
+        AlertDialog(
+            onDismissRequest = {
+                chatRepositoryViewModel.showMessageApprovedDialog.value = false
+            },
+            title = {
+                Text("Active Chat")
+            },
+            text = {
+                Text("You already have an active chat with $receiverUserName")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        chatRepositoryViewModel.showMessageApprovedDialog.value = false
+                    }
+                ) {
+                    Text("Ok")
+                }
+            }
+        )
+    }
+
+    val context = LocalContext.current
+    chatRepositoryViewModel.confirmSendMessageRequest.value?.let { confirmSendMessageRequest ->
+        Toast.makeText(
+            context,
+            confirmSendMessageRequest,
+            Toast.LENGTH_SHORT
+        ).show()
+        chatRepositoryViewModel.confirmSendMessageRequest.value = null
     }
 }

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -273,10 +273,10 @@ fun PeopleScreen() {
                                                 Icon(
                                                     imageVector = Icons.Default.Email,
                                                     contentDescription = "Send Message Request",
-                                                    tint = HeaderRed
+                                                    tint = NavText
                                                 )
                                                 Spacer(modifier = Modifier.width(8.dp))
-                                                Text("Send Message Request", color = HeaderRed)
+                                                Text("Send Message Request", color = NavText)
                                             }
                                         },
                                         onClick = {
@@ -285,8 +285,6 @@ fun PeopleScreen() {
                                                 senderID,
                                                 uid,
                                             )
-                                            //chatRepositoryViewModel.loadMessageRequest(senderID)
-                                            //chatRepositoryViewModel.loadMessageRequest(uid)
                                             showMenu = false
                                         }
                                     )

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -24,6 +24,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.phinui.components.messages.User
 import com.example.phinui.ui.theme.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.ui.input.pointer.motionEventSpy
 import androidx.lifecycle.viewModelScope
 import com.example.phinui.data.friends.FriendRepository
 import com.example.phinui.viewmodel.ChatRepositoryViewModel
@@ -40,7 +45,6 @@ fun UserListScreen (
         factory = FriendRepositoryViewModelFactory(FriendRepository())
     )) {
 
-    val messageRequest = chatRepositoryViewModel.messageRequests
     val currentUserID = chatRepositoryViewModel.currentUserID ?: return
     val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
@@ -49,6 +53,10 @@ fun UserListScreen (
     LaunchedEffect(currentUserID){
         chatRepositoryViewModel.loadMessageRequest(currentUserID)
     }
+
+    //LaunchedEffect(currentUserID){
+    //    chatRepositoryViewModel.loadApprovedChats(currentUserID)
+    //}
     //END OF ADDED
     Column(modifier = Modifier
         .fillMaxSize()
@@ -100,30 +108,16 @@ fun UserListScreen (
 
             //Requests tab
             2 -> {
-                //ADDED 4/13
-                var messageRequestState by remember { mutableStateOf<List<Map<String, Any>>>(emptyList()) }
-                LaunchedEffect(currentUserID){
-                    chatRepositoryViewModel.loadMessageRequest(currentUserID)
-                }
-
-                LaunchedEffect(messageRequestState) {
-                    messageRequestState = chatRepositoryViewModel.messageRequests.value
-                }
-                //END OF ADDED
+                val messageRequestState = chatRepositoryViewModel.messageRequests.value
                 Box {
-                    //LaunchedEffect(Unit) {
-                    //    val uid = chatRepositoryViewModel.currentUserID ?: return@LaunchedEffect
-                    //    chatRepositoryViewModel.loadMessageRequest(uid)
-                    //}
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(20.dp),
+                            .padding(10.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        //items(messageRequest.value) { chat ->
                         items(messageRequestState) { chat ->
-                        val chatID = chat["chatID"] as? String ?: return@items
+                            val chatID = chat["chatID"] as? String ?: return@items
                             val participants = chat["participants"] as? List<*> ?: return@items
 
                             val otherUserID = participants
@@ -152,19 +146,50 @@ fun UserListScreen (
                             UserListItem(
                                 user = user,
                                 trailingContent = {
-                                    Row{
-                                        Button(onClick = {
-                                            chatRepositoryViewModel.approveRequest(chatID)
-                                        }) {
-                                            Text("Accept")
+                                    var showMenu by remember { mutableStateOf(false) }
+                                    Box {
+                                        IconButton(
+                                            onClick = { showMenu = !showMenu }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.MoreVert,
+                                                contentDescription = "Options",
+                                                tint = NavText
+                                            )
                                         }
 
-                                        Spacer(modifier = Modifier.width(8.dp))
+                                        DropdownMenu(
+                                            expanded = showMenu,
+                                            onDismissRequest = { showMenu = false },
+                                            containerColor = Background
+                                        ) {
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(Icons.Default.Check, contentDescription = "Accept", tint = NavText)
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Accept", color = NavText)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    chatRepositoryViewModel.approveRequest(chatID)
+                                                }
+                                            )
 
-                                        Button(onClick = {
-                                            chatRepositoryViewModel.denyRequest(chatID)
-                                        }) {
-                                            Text("Decline")
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(Icons.Default.Delete, contentDescription = "Decline", tint = HeaderRed)
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Decline", color = HeaderRed)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    chatRepositoryViewModel.denyRequest(chatID)
+                                                }
+                                            )
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -88,7 +88,7 @@ fun UserListScreen (
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(20.dp),
+                            .padding(10.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         items(friendList) { friend ->
@@ -116,7 +116,6 @@ fun UserListScreen (
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         items(approvedChatsState) { chat ->
-                            //val chatID = chat["chatID"] as? String ?: return@items
                             val participants = chat["participants"] as? List<*> ?: return@items
 
                             val otherUserID = participants

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.ui.input.pointer.motionEventSpy
 import androidx.lifecycle.viewModelScope
 import com.example.phinui.data.friends.FriendRepository
@@ -54,9 +55,9 @@ fun UserListScreen (
         chatRepositoryViewModel.loadMessageRequest(currentUserID)
     }
 
-    //LaunchedEffect(currentUserID){
-    //    chatRepositoryViewModel.loadApprovedChats(currentUserID)
-    //}
+    LaunchedEffect(currentUserID){
+        chatRepositoryViewModel.loadApprovedChats(currentUserID)
+    }
     //END OF ADDED
     Column(modifier = Modifier
         .fillMaxSize()
@@ -105,6 +106,102 @@ fun UserListScreen (
             }
 
             //General tab
+            1 -> {
+                val approvedChatsState = chatRepositoryViewModel.approvedChats.value
+                //val approvedChatsState = chatRepositoryViewModel.getGeneralChats()
+                Box {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(10.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        items(approvedChatsState) { chat ->
+                            val chatID = chat["chatID"] as? String ?: return@items
+                            val participants = chat["participants"] as? List<*> ?: return@items
+
+                            val otherUserID = participants
+                                .mapNotNull { it as? String }
+                                .firstOrNull{ it != currentUserID } ?:return@items
+
+                            var userName by remember { mutableStateOf("Loading...")}
+
+                            LaunchedEffect(otherUserID) {
+                                chatRepositoryViewModel.userListRepository.getUserNameByID(
+                                    otherUserID,
+                                    onResult = { user ->
+                                        userName = user.name
+                                    },
+                                    onError = {exception ->
+                                        userName = "Unknown User"
+                                    }
+                                )
+                            }
+
+                            val user = User(
+                                uid = otherUserID,
+                                name = userName
+                            )
+
+                            UserListItem(
+                                user = user,
+                                trailingContent = {
+                                    var showMenu by remember { mutableStateOf(false) }
+                                    Box {
+                                        IconButton(
+                                            onClick = { showMenu = !showMenu }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.MoreVert,
+                                                contentDescription = "Options",
+                                                tint = NavText
+                                            )
+                                        }
+
+                                        DropdownMenu(
+                                            expanded = showMenu,
+                                            onDismissRequest = { showMenu = false },
+                                            containerColor = Background
+                                        ) {
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(Icons.Default.PersonAdd, contentDescription = "Add Friend", tint = NavText)
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Add Friend", color = NavText)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    //chatRepositoryViewModel.approveRequest(chatID)
+                                                }
+                                            )
+
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(Icons.Default.Delete, contentDescription = "Delete", tint = HeaderRed)
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Delete", color = HeaderRed)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    //chatRepositoryViewModel.denyRequest(chatID)
+                                                }
+                                            )
+                                        }
+                                    }
+                                },
+                                onClick = {
+                                    navController.navigate(Routes.MESSAGES + "/${user.uid}")
+                                }
+                            )
+                            Spacer(modifier = Modifier.height(5.dp))
+                        }
+                    }
+                }
+            }
 
             //Requests tab
             2 -> {

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -50,7 +50,6 @@ fun UserListScreen (
     val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
 
-    //ADDED 4/13
     LaunchedEffect(currentUserID){
         chatRepositoryViewModel.loadMessageRequest(currentUserID)
     }
@@ -58,7 +57,7 @@ fun UserListScreen (
     LaunchedEffect(currentUserID){
         chatRepositoryViewModel.loadApprovedChats(currentUserID)
     }
-    //END OF ADDED
+
     Column(modifier = Modifier
         .fillMaxSize()
         .padding(20.dp),
@@ -107,8 +106,8 @@ fun UserListScreen (
 
             //General tab
             1 -> {
-                val approvedChatsState = chatRepositoryViewModel.approvedChats.value
-                //val approvedChatsState = chatRepositoryViewModel.getGeneralChats()
+                val approvedChatsState = chatRepositoryViewModel.getGeneralChats.value
+
                 Box {
                     LazyColumn(
                         modifier = Modifier
@@ -117,7 +116,7 @@ fun UserListScreen (
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         items(approvedChatsState) { chat ->
-                            val chatID = chat["chatID"] as? String ?: return@items
+                            //val chatID = chat["chatID"] as? String ?: return@items
                             val participants = chat["participants"] as? List<*> ?: return@items
 
                             val otherUserID = participants
@@ -145,54 +144,54 @@ fun UserListScreen (
 
                             UserListItem(
                                 user = user,
-                                trailingContent = {
-                                    var showMenu by remember { mutableStateOf(false) }
-                                    Box {
-                                        IconButton(
-                                            onClick = { showMenu = !showMenu }
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Default.MoreVert,
-                                                contentDescription = "Options",
-                                                tint = NavText
-                                            )
-                                        }
-
-                                        DropdownMenu(
-                                            expanded = showMenu,
-                                            onDismissRequest = { showMenu = false },
-                                            containerColor = Background
-                                        ) {
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                                        Icon(Icons.Default.PersonAdd, contentDescription = "Add Friend", tint = NavText)
-                                                        Spacer(modifier = Modifier.width(8.dp))
-                                                        Text("Add Friend", color = NavText)
-                                                    }
-                                                },
-                                                onClick = {
-                                                    showMenu = false
-                                                    //chatRepositoryViewModel.approveRequest(chatID)
-                                                }
-                                            )
-
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                                        Icon(Icons.Default.Delete, contentDescription = "Delete", tint = HeaderRed)
-                                                        Spacer(modifier = Modifier.width(8.dp))
-                                                        Text("Delete", color = HeaderRed)
-                                                    }
-                                                },
-                                                onClick = {
-                                                    showMenu = false
-                                                    //chatRepositoryViewModel.denyRequest(chatID)
-                                                }
-                                            )
-                                        }
-                                    }
-                                },
+//                                trailingContent = {
+//                                    var showMenu by remember { mutableStateOf(false) }
+//                                    Box {
+//                                        IconButton(
+//                                            onClick = { showMenu = !showMenu }
+//                                        ) {
+//                                            Icon(
+//                                                imageVector = Icons.Default.MoreVert,
+//                                                contentDescription = "Options",
+//                                                tint = NavText
+//                                            )
+//                                        }
+//
+//                                        DropdownMenu(
+//                                            expanded = showMenu,
+//                                            onDismissRequest = { showMenu = false },
+//                                            containerColor = Background
+//                                        ) {
+//                                            DropdownMenuItem(
+//                                                text = {
+//                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+//                                                        Icon(Icons.Default.PersonAdd, contentDescription = "Add Friend", tint = NavText)
+//                                                        Spacer(modifier = Modifier.width(8.dp))
+//                                                        Text("Add Friend", color = NavText)
+//                                                    }
+//                                                },
+//                                                onClick = {
+//                                                    showMenu = false
+//                                                    //chatRepositoryViewModel.approveRequest(chatID)
+//                                                }
+//                                            )
+//
+//                                            DropdownMenuItem(
+//                                                text = {
+//                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+//                                                        Icon(Icons.Default.Delete, contentDescription = "Delete", tint = HeaderRed)
+//                                                        Spacer(modifier = Modifier.width(8.dp))
+//                                                        Text("Delete", color = HeaderRed)
+//                                                    }
+//                                                },
+//                                                onClick = {
+//                                                    showMenu = false
+//                                                    //chatRepositoryViewModel.denyRequest(chatID)
+//                                                }
+//                                            )
+//                                        }
+//                                    }
+//                                },
                                 onClick = {
                                     navController.navigate(Routes.MESSAGES + "/${user.uid}")
                                 }

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.phinui.viewmodel
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -27,6 +28,11 @@ class ChatRepositoryViewModel (
     val approvedChats = mutableStateOf<List<Map<String, Any>>>(emptyList())
     val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
 
+    val showMessageApprovedDialog = mutableStateOf(false)
+    var activeChatUserName = mutableStateOf<String?>(null)
+
+    val confirmSendMessageRequest = mutableStateOf<String?>(null)
+
     // FOR FILTERING FRIENDS FROM GENERAL
     val friendsList = mutableStateOf<List<User>>(emptyList())
 
@@ -41,6 +47,12 @@ class ChatRepositoryViewModel (
                 }
             }, onError = { exception -> Log.e("Friends", "Error", exception) }
         )
+    }
+
+    fun startListening(userID: String) {
+        chatRepository.listenChats(userID) { chats ->
+            approvedChats.value = chats
+        }
     }
 
     val getGeneralChats = derivedStateOf {
@@ -69,8 +81,27 @@ class ChatRepositoryViewModel (
         }
     }
 
-    fun sendMessageRequest(senderUserID: String, receiverUserID: String) {
-        chatRepository.sendMessageRequest(senderUserID, receiverUserID)
+    fun sendMessageRequest(senderUserID: String, receiverUserID: String, receiverUserName: String?) {
+        val checkChat = approvedChats.value.firstOrNull{ chat ->
+            val participants = chat["participants"] as? List<*>
+            val userIDs = participants?.mapNotNull { it as? String} ?: emptyList()
+
+            senderUserID in userIDs && receiverUserID in userIDs
+        }
+
+        val isMessageRequestApproved = checkChat?.get("messageRequestApproved") as? Boolean ?: false
+        if (isMessageRequestApproved) {
+            showMessageApprovedDialog.value = true
+            activeChatUserName.value = receiverUserName
+        }
+        else {
+            try {
+                chatRepository.sendMessageRequest(senderUserID, receiverUserID)
+                confirmSendMessageRequest.value = "Message request sent"
+            } catch (e: Exception) {
+                confirmSendMessageRequest.value = e.message ?: "Failed to send request."
+            }
+        }
     }
 
     fun approveRequest(chatID: String) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.phinui.viewmodel
 
+import android.util.Log
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -15,7 +16,7 @@ import kotlinx.coroutines.tasks.await
 
 class ChatRepositoryViewModel (
     private val chatRepository: ChatRepository = ChatRepository(),
-    //private val friendRepository: FriendRepository = FriendRepository(),
+    private val friendRepository: FriendRepository = FriendRepository(),
     val userListRepository: UserListRepository = UserListRepository()
 ) : ViewModel() {
 
@@ -27,29 +28,34 @@ class ChatRepositoryViewModel (
     val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
 
     // FOR FILTERING FRIENDS FROM GENERAL
-//    val friendsList = mutableStateOf<List<User>>(emptyList())
-//
-//    init {
-//        friendRepository.listenFriends(
-//            onResult = { friends ->
-//                friendsList.value = friends.map {
-//                    User(
-//                        uid = it.first,
-//                        name = it.second["name"] as? String ?: "Unknown"
-//                    )
-//                }
-//            }, onError = { Exception -> Unit }
-//        )
-//    }
-//
-//    fun getGeneralChats(): List<Map<String, Any>> {
-//        val friendIDs = friendsList.value.map { it.uid }.toSet()
-//
-//        return approvedChats.value.filter{ chat ->
-//            val otherUserID = chat["otherUserID"] as? String
-//            otherUserID!= null && otherUserID !in friendIDs
-//        }
-//    }
+    val friendsList = mutableStateOf<List<User>>(emptyList())
+
+    init {
+        friendRepository.listenFriends(
+            onResult = { friends ->
+                friendsList.value = friends.map {
+                    User(
+                        uid = it.first,
+                        name = it.second["name"] as? String ?: "Unknown"
+                    )
+                }
+            }, onError = { exception -> Log.e("Friends", "Error", exception) }
+        )
+    }
+
+    val getGeneralChats = derivedStateOf {
+        val friendIDs = friendsList.value.map { it.uid }.toSet()
+
+        approvedChats.value.filter{ chat ->
+            val participants = chat["participants"] as? List<*> ?: return@filter false
+
+            val otherUserID = participants
+                .mapNotNull { it as? String }
+                .firstOrNull{ it != currentUserID }
+
+            otherUserID!= null && otherUserID !in friendIDs
+        }
+    }
 
     fun loadApprovedChats(userID: String) {
         chatRepository.listenChats(userID) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -1,11 +1,13 @@
 package com.example.phinui.viewmodel
 
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.phinui.components.messages.ChatRepository
 import com.example.phinui.components.messages.User
 import com.example.phinui.components.messages.UserListRepository
+import com.example.phinui.data.friends.FriendRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.launch
@@ -13,6 +15,7 @@ import kotlinx.coroutines.tasks.await
 
 class ChatRepositoryViewModel (
     private val chatRepository: ChatRepository = ChatRepository(),
+    //private val friendRepository: FriendRepository = FriendRepository(),
     val userListRepository: UserListRepository = UserListRepository()
 ) : ViewModel() {
 
@@ -22,6 +25,31 @@ class ChatRepositoryViewModel (
     //val currentUserID = FirebaseAuth.getInstance().currentUser?.uid
     val approvedChats = mutableStateOf<List<Map<String, Any>>>(emptyList())
     val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
+
+    // FOR FILTERING FRIENDS FROM GENERAL
+//    val friendsList = mutableStateOf<List<User>>(emptyList())
+//
+//    init {
+//        friendRepository.listenFriends(
+//            onResult = { friends ->
+//                friendsList.value = friends.map {
+//                    User(
+//                        uid = it.first,
+//                        name = it.second["name"] as? String ?: "Unknown"
+//                    )
+//                }
+//            }, onError = { Exception -> Unit }
+//        )
+//    }
+//
+//    fun getGeneralChats(): List<Map<String, Any>> {
+//        val friendIDs = friendsList.value.map { it.uid }.toSet()
+//
+//        return approvedChats.value.filter{ chat ->
+//            val otherUserID = chat["otherUserID"] as? String
+//            otherUserID!= null && otherUserID !in friendIDs
+//        }
+//    }
 
     fun loadApprovedChats(userID: String) {
         chatRepository.listenChats(userID) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -23,8 +23,6 @@ class ChatRepositoryViewModel (
     val approvedChats = mutableStateOf<List<Map<String, Any>>>(emptyList())
     val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
 
-    //val requestUsers = mutableStateOf<List<User>>(emptyList())
-
     fun loadApprovedChats(userID: String) {
         chatRepository.listenChats(userID) {
             approvedChats.value = it
@@ -36,31 +34,6 @@ class ChatRepositoryViewModel (
             messageRequests.value = it
         }
     }
-
-//    fun loadRequestUsers(currentUserID: String) {
-//        chatRepository.listenMessageRequest(currentUserID) { chats ->
-//            viewModelScope.launch {
-//                //val users = chats.mapNotNull { chat ->
-//                val users = mutableListOf<User>()
-//                for (chat in chats) {
-//                    val participants =
-//                        //chat["participants"] as? List<String> ?: return@mapNotNull null
-//                        chat["participants"] as? List<String> ?: continue
-//
-//                    val otherUserID =
-//                        //participants.firstOrNull { it != currentUserID } ?: return@mapNotNull null
-//                        participants.firstOrNull { it != currentUserID } ?: continue
-//                    //getUserNameByID(otherUserID)
-//                    userListRepository.getUserNameByID(otherUserID, { user ->
-//                        users.add(user)
-//                    }, { exception ->
-//                        println("Error fetching user: ${exception.message}")
-//                    })
-//                    requestUsers.value = users
-//                }
-//            }
-//        }
-//    }
 
     fun sendMessageRequest(senderUserID: String, receiverUserID: String) {
         chatRepository.sendMessageRequest(senderUserID, receiverUserID)
@@ -74,23 +47,4 @@ class ChatRepositoryViewModel (
         chatRepository.denyMessageRequest(chatID)
     }
 
-//    fun getUserNameByID(
-//        userID: String,
-//        onResult: (User) -> Unit,
-//        onError: (Exception) -> Unit) {
-//
-//        firebaseFirestoreAuthenticated.collection("users").document(userID)
-//            .get()
-//            .addOnSuccessListener { document ->
-//                if (document.exists()) {
-//                    val userName = document.getString("name") ?: "Unknown User"
-//                    val user = User(uid = userID, name = userName)
-//                    onResult(user)
-//            } else {
-//                onError(Exception("User not found"))
-//                }
-//        }.addOnFailureListener { exception ->
-//            onError(exception)
-//            }
-//    }
 }


### PR DESCRIPTION
**Updates**

- Users can now accept or deny message requests
    - If the receiving user accepts the request from the "Requests" tab on the UserListScreen (aka Messages), then the chat will be moved to the "General" tab
    - If the receiving user denies the request, the message request and entire chat instance from the requestor is deleted
        -  Whenever a user sends a message request, a chat document is automatically created/stored in firestore with no context/messages.
        - The deletion of the chat document should not be an issue since they won't have any messages between them when they are sending the message request.
- User sending the request will receive a notification
    - When they click on the "Send Message Request" button, they'll receive a Toast notification that the request was sent
    - If they already have an active chat and they attempt to send a message request, they'll receive an AlertDialog box indicating as such.

**To Do:**
- Prevent blocked users from sending a message request
- Prevent blocked users from sending messages if they already had an active chat before being blocked
- Possibly notify the user they already sent a message request if they click on the "Send Message Request" button more than once
- Alphabetize the user list in the General and Request tabs
