### PR TITLE
added notifications for friend requests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,4 +106,7 @@ dependencies {
     //course catalog
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jsoup:jsoup:1.17.2")
+
+    // fcm
+    implementation("com.google.firebase:firebase-messaging:25.0.1")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,15 @@
                 <data android:scheme="phin" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".notifications.PhinFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAPS_API_KEY}" />

--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -41,6 +41,7 @@ import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.example.phinui.components.messages.UserListRepository
 import com.example.phinui.data.authorization.GoogleAuthManager
+import com.example.phinui.notifications.NotificationHelper.createNotificationChannels
 import com.example.phinui.screens.UserListScreen
 
 //firebase
@@ -68,6 +69,8 @@ fun PhinNavHost(
     val coroutineScope = rememberCoroutineScope()
     val auth = remember { FirebaseAuth.getInstance() }
     val startDestination = if (auth.currentUser != null) Routes.HOME else Routes.LOGIN
+
+    createNotificationChannels(context)
 
     LaunchedEffect(Unit) {
         val loaded = storeEvent.loadEvents()
@@ -220,7 +223,14 @@ fun PhinNavHost(
             PeopleScreen()
         }
 
-        composable(Routes.FRIENDS) {
+        composable(
+            Routes.FRIENDS,
+            deepLinks = listOf(
+                navDeepLink {
+                    uriPattern = "phin://friends"
+                }
+            )
+        ) {
             FriendsScreen(navController = navController)
         }
 

--- a/app/src/main/java/com/example/phinui/notifications/FCMTokenManager.kt
+++ b/app/src/main/java/com/example/phinui/notifications/FCMTokenManager.kt
@@ -1,0 +1,22 @@
+package com.example.phinui.notifications
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.messaging.FirebaseMessaging
+
+object FCMTokenManager {
+
+    fun registerToken() {
+        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return
+
+        FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
+            val data = mapOf("fcmToken" to token)
+
+            FirebaseFirestore.getInstance()
+                .collection("users")
+                .document(userId)
+                .set(data, SetOptions.merge())
+        }
+    }
+}

--- a/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
@@ -1,0 +1,57 @@
+package com.example.phinui.notifications
+
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import com.example.phinui.MainActivity
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class PhinFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        // send the token to the database
+        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        FirebaseFirestore.getInstance()
+            .collection("users")
+            .document(userId)
+            .set(mapOf("fcmToken" to token), SetOptions.merge())
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+
+        Log.d("FCM_DEBUG", "DATA: ${remoteMessage.data}")
+        Log.d("FCM_DEBUG", "TYPE: ${remoteMessage.data["type"]}")
+        val title = remoteMessage.data["title"] ?: "Notification"
+        val body = remoteMessage.data["body"] ?: ""
+        val type = remoteMessage.data["type"]
+
+        val launchIntent = when (type) {
+
+            "FRIEND_REQUEST" ->
+                Intent(Intent.ACTION_VIEW, Uri.parse("phin://friends")).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+
+            else ->
+                Intent(this, MainActivity::class.java)
+
+
+        }
+
+        NotificationHelper.showNotification(
+            context = this,
+            type = NotificationType.FRIEND_REQUESTS,
+            title = title,
+            body = body,
+            intent = launchIntent,
+            requestCode = System.currentTimeMillis().toInt()
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/phinui/notifications/NotificationHelper.kt
+++ b/app/src/main/java/com/example/phinui/notifications/NotificationHelper.kt
@@ -24,34 +24,10 @@ object NotificationHelper {
         eventId: String,
     ) {
 
-        // need to make sure to update this whenever editing notification build
-        val channelId = "reminders_v3"
-
-        val manager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                channelId,
-                "Reminders",
-                NotificationManager.IMPORTANCE_HIGH
-            )
-
-            manager.createNotificationChannel(channel)
-        }
-
         val intent =
             Intent(Intent.ACTION_VIEW, Uri.parse("phin://calendar")).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             }
-
-        // changed Intent(context, MainActivity::class.java) to intent
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
 
         val contentTitle =
             if (title == null) {
@@ -60,31 +36,15 @@ object NotificationHelper {
                 "Upcoming Event"
             }
 
-        val notification = NotificationCompat.Builder(context, channelId)
-            .setContentTitle(contentTitle)
-            .setContentText(title)
-            .setSmallIcon(R.drawable.redphin)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setContentIntent(pendingIntent)
-            .setAutoCancel(true)
-            .build()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            Log.d("NotifDebug", "Permission not granted to send notifications")
-            return
-        }
-
-        NotificationManagerCompat.from(context)
-            .notify(eventId.hashCode(), notification)
-
+        showNotification(
+            context = context,
+            type = NotificationType.CALENDAR,
+            title = contentTitle,
+            body = title,
+            intent = intent,
+            requestCode = eventId.hashCode()
+        )
     }
-
-    // functions for potential future use of other notification types
 
     fun createNotificationChannels(context: Context) {
         val manager =
@@ -105,33 +65,29 @@ object NotificationHelper {
         }
     }
 
-    fun sendNotification(
+    fun showNotification(
         context: Context,
         type: NotificationType,
-        customTitle: String? = null,
-        customMessage: String? = null
+        title: String?,
+        body: String?,
+        intent: Intent,
+        requestCode: Int = 0
     ) {
-
-        val title = customTitle ?: type.title
-        val message = customMessage ?: type.message
-
-        val intent = Intent(context, MainActivity::class.java).apply {
-            putExtra("notificationType", type.name)
-        }
-
         val pendingIntent = PendingIntent.getActivity(
             context,
-            type.ordinal,
+            requestCode,
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val builder = NotificationCompat.Builder(context, type.channelId)
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
-            .setContentTitle(title)
-            .setContentText(message)
+        val notification = NotificationCompat.Builder(context, type.channelId)
+            .setContentTitle(title ?: type.channelName)
+            .setContentText(body)
+            .setSmallIcon(R.drawable.redphin)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
+            .build()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(
@@ -139,11 +95,11 @@ object NotificationHelper {
                 Manifest.permission.POST_NOTIFICATIONS
             ) != PackageManager.PERMISSION_GRANTED
         ) {
-            Log.d("NotifDebug", "Permission not granted to send notifications")
+            Log.d("NotifDebug", "Notification permission not granted")
             return
         }
 
         NotificationManagerCompat.from(context)
-            .notify(type.ordinal, builder.build())
+            .notify(requestCode, notification)
     }
 }

--- a/app/src/main/java/com/example/phinui/notifications/NotificationTypes.kt
+++ b/app/src/main/java/com/example/phinui/notifications/NotificationTypes.kt
@@ -6,31 +6,17 @@ enum class NotificationType(
     val channelId: String,
     val channelName: String,
     val importance: Int,
-    val title: String,
-    val message: String
 ) {
 
-    SCHEDULE(
-        "schedule",
-        "Schedule",
-        NotificationManager.IMPORTANCE_HIGH,
-        "Schedule Reminder",
-        "Your class will start soon!"
+    CALENDAR(
+        "calendar_reminders",
+        "Calendar Reminders V2",
+        NotificationManager.IMPORTANCE_HIGH
     ),
 
-    ASSIGNMENT(
-        "assignment",
-        "Assignment",
-        NotificationManager.IMPORTANCE_HIGH,
-        "Assignment Due",
-        "You have an assignment due soon!"
-    ),
-
-    EVENT(
-        "event",
-        "Event",
-        NotificationManager.IMPORTANCE_HIGH,
-        "Event Reminder",
-        "There is an event coming up!"
+    FRIEND_REQUESTS(
+        "friend_request_channel",
+        "Friend Requests V2",
+        NotificationManager.IMPORTANCE_HIGH
     )
 }

--- a/app/src/main/java/com/example/phinui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/LoginScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.font.FontWeight
+import com.example.phinui.notifications.FCMTokenManager
 import com.example.phinui.ui.components.AuthHeader
 
 @Composable
@@ -114,6 +115,7 @@ fun LoginScreen(
                         .addOnCompleteListener { task ->
                             loading = false
                             if (task.isSuccessful) {
+                                FCMTokenManager.registerToken()
                                 onLoginSuccess()
                             } else {
                                 errorMessage = "Incorrect Email or Password."


### PR DESCRIPTION
- set up notifications for when a user taps the add friend button that should get sent to the user they're trying to friend
- cleaned up the notification helper file by making the methods more general use, so they should currently work for both calendar reminders and incoming friend requests
- notification should work whether the app is open or closed
- notification should navigate to friend screen when tapped
- uses firebase cloud messaging and cloud functions, which hopefully work for everyone else
- for testing, I recommend having two emulators open if possible, so that you can see the notification pop up in real time