### PR TITLE
Messaging - Prevent blocked users from messaging

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/UserListRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/UserListRepository.kt
@@ -1,6 +1,7 @@
 package com.example.phinui.components.messages
 
 import androidx.compose.animation.core.snap
+import androidx.compose.runtime.mutableStateOf
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 
@@ -12,6 +13,10 @@ data class User(
 class UserListRepository {
     private val database = FirebaseFirestore.getInstance()
     private val usersCollection = database.collection("users")
+
+    val currentUserBlockedList = mutableStateOf<Set<String>>(emptySet())
+    val blockedByOtherUsersList = mutableStateOf<Set<String>>(emptySet())
+
 
     suspend fun getAllUsers(currentUserID: String): List<User> {
         return try {
@@ -64,4 +69,29 @@ class UserListRepository {
             onError(exception)
             }
     }
+
+    fun loadCurrentUserBlockedListListener(currentUserID: String) {
+        usersCollection
+            .document(currentUserID)
+            .addSnapshotListener { snapshot, error ->
+                if (error !=null || snapshot == null) return@addSnapshotListener
+                val blockedList = (snapshot.get("blocked") as? List<*> ?: emptyList<Any>())
+                    .mapNotNull { it as? String }
+                    .toSet()
+                currentUserBlockedList.value = blockedList
+            }
+    }
+
+    fun loadBlockedByOtherUsersListListener(currentUserID: String) {
+        usersCollection
+            .whereArrayContains("blocked", currentUserID)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null || snapshot == null) return@addSnapshotListener
+                val blockedList = snapshot.documents
+                    .map { it.id }
+                    .toSet()
+                blockedByOtherUsersList.value = blockedList
+            }
+    }
+
 }

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -58,6 +58,16 @@ fun UserListScreen (
         chatRepositoryViewModel.loadApprovedChats(currentUserID)
     }
 
+    LaunchedEffect(currentUserID) {
+        chatRepositoryViewModel.userListRepository.loadCurrentUserBlockedListListener(currentUserID)
+        chatRepositoryViewModel.userListRepository.loadBlockedByOtherUsersListListener(currentUserID)
+    }
+
+    val currentUserBlockedList = chatRepositoryViewModel.userListRepository.currentUserBlockedList.value
+    val blockedByOtherUsersList = chatRepositoryViewModel.userListRepository.blockedByOtherUsersList.value
+    val hideBlockedUsers = currentUserBlockedList + blockedByOtherUsersList
+
+
     Column(modifier = Modifier
         .fillMaxSize()
         .padding(20.dp),
@@ -121,6 +131,8 @@ fun UserListScreen (
                             val otherUserID = participants
                                 .mapNotNull { it as? String }
                                 .firstOrNull{ it != currentUserID } ?:return@items
+
+                            if(otherUserID in hideBlockedUsers) return@items
 
                             var userName by remember { mutableStateOf("Loading...")}
 

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -102,6 +102,7 @@ fun UserListScreen (
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         items(friendList) { friend ->
+                            if(friend.uid in hideBlockedUsers) return@items
                             UserListItem(
                                 user = friend,
                                 onClick = {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.core.os.registerForAllProfilingResults
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.phinui.components.messages.ChatRepository
@@ -24,7 +25,6 @@ class ChatRepositoryViewModel (
     val firebaseAuthenticated = FirebaseAuth.getInstance()
     val firebaseFirestoreAuthenticated = FirebaseFirestore.getInstance()
     val currentUserID = firebaseAuthenticated.currentUser?.uid
-    //val currentUserID = FirebaseAuth.getInstance().currentUser?.uid
     val approvedChats = mutableStateOf<List<Map<String, Any>>>(emptyList())
     val messageRequests = mutableStateOf<List<Map<String, Any>>>(emptyList())
 
@@ -82,24 +82,73 @@ class ChatRepositoryViewModel (
     }
 
     fun sendMessageRequest(senderUserID: String, receiverUserID: String, receiverUserName: String?) {
-        val checkChat = approvedChats.value.firstOrNull{ chat ->
-            val participants = chat["participants"] as? List<*>
-            val userIDs = participants?.mapNotNull { it as? String} ?: emptyList()
+        val currentUserDocument = firebaseFirestoreAuthenticated
+            .collection("users")
+            .document(senderUserID)
 
-            senderUserID in userIDs && receiverUserID in userIDs
-        }
+        val targetUserDocument = firebaseFirestoreAuthenticated
+            .collection("users")
+            .document(receiverUserID)
 
-        val isMessageRequestApproved = checkChat?.get("messageRequestApproved") as? Boolean ?: false
-        if (isMessageRequestApproved) {
-            showMessageApprovedDialog.value = true
-            activeChatUserName.value = receiverUserName
+        firebaseFirestoreAuthenticated.runTransaction { transaction ->
+            val currentUserDocumentSnapshot = transaction.get(currentUserDocument)
+            val targetUserDocumentSnapshot = transaction.get(targetUserDocument)
+            val currentUserBlockedList =
+                (currentUserDocumentSnapshot.get("blocked") as? List<*> ?: emptyList<Any>())
+                    .mapNotNull { it as? String }
+            val targetUserBlockedList =
+                (targetUserDocumentSnapshot.get("blocked") as? List<*> ?: emptyList<Any>())
+                    .mapNotNull { it as? String }
+
+            if (currentUserBlockedList.contains(receiverUserID)) {
+                // exit function
+                throw Exception("CURRENT_USER_BLOCKED_TARGET_USER")
+            }
+
+            if (targetUserBlockedList.contains(senderUserID)) {
+                // exit function
+                throw Exception("TARGET_USER_BLOCKED_CURRENT_USER")
+            }
+
+            val checkChat = approvedChats.value.firstOrNull { chat ->
+                val participants = chat["participants"] as? List<*>
+                val userIDs = participants?.mapNotNull { it as? String } ?: emptyList()
+
+                senderUserID in userIDs && receiverUserID in userIDs
+            }
+
+            val isMessageRequestApproved =
+                checkChat?.get("messageRequestApproved") as? Boolean ?: false
+            if (isMessageRequestApproved) {
+                return@runTransaction "CHAT_EXISTS"
+            }
+
+            return@runTransaction "SEND_REQUEST"
         }
-        else {
-            try {
-                chatRepository.sendMessageRequest(senderUserID, receiverUserID)
-                confirmSendMessageRequest.value = "Message request sent"
-            } catch (e: Exception) {
-                confirmSendMessageRequest.value = e.message ?: "Failed to send request."
+            .addOnSuccessListener { result ->
+                when (result) {
+                    "CHAT_EXISTS" -> {
+                        showMessageApprovedDialog.value = true
+                        activeChatUserName.value = receiverUserName
+                    }
+                    "SEND_REQUEST" -> {
+                        chatRepository.sendMessageRequest(senderUserID, receiverUserID)
+                        confirmSendMessageRequest.value = "Message request sent"
+                    }
+                }
+            }
+
+            .addOnFailureListener { error ->
+            when (error.message) {
+                "CURRENT_USER_BLOCKED_TARGET_USER" -> {
+                    confirmSendMessageRequest.value = "Unable to send request"
+                }
+                "TARGET_USER_BLOCKED_CURRENT_USER" -> {
+                    confirmSendMessageRequest.value = "Unable to send request"
+                }
+                else -> {
+                    confirmSendMessageRequest.value = "Failed to send request"
+                }
             }
         }
     }


### PR DESCRIPTION
**Updates**

- Prevent blocked users from sending a message request
    - If a user is blocked by the person they are trying to send the message request to, they'll receive an "Unable to send request" toast message
- Prevent blocked users from sending messages if they already had an active chat before being blocked
    - The chat will no longer appear in either the friends or general tabs

**To Do**
- Possibly notify the user they already sent a message request if they click on the "Send Message Request" button more than once
- Alphabetize the user list in the General and Request tabs