### PR TITLE
added notifications for accepted friend request

### DIFF
--- a/app/src/main/java/com/example/phinui/MainActivity.kt
+++ b/app/src/main/java/com/example/phinui/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.phinui
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -61,6 +62,11 @@ class MainActivity : ComponentActivity() {
                 PhinUIApp()
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
     }
 }
 

--- a/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
@@ -30,11 +30,17 @@ class PhinFirebaseMessagingService : FirebaseMessagingService() {
         val title = remoteMessage.data["title"] ?: "Notification"
         val body = remoteMessage.data["body"] ?: ""
         val type = remoteMessage.data["type"]
+        val uri = remoteMessage.data["uri"]
 
         val launchIntent = when (type) {
 
             "FRIEND_REQUEST" ->
-                Intent(Intent.ACTION_VIEW, Uri.parse("phin://friends")).apply {
+                Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+
+            "FRIEND_ACCEPTED" ->
+                Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
 

--- a/app/src/main/java/com/example/phinui/notifications/NotificationTypes.kt
+++ b/app/src/main/java/com/example/phinui/notifications/NotificationTypes.kt
@@ -16,7 +16,7 @@ enum class NotificationType(
 
     FRIEND_REQUESTS(
         "friend_request_channel",
-        "Friend Requests V2",
+        "Friend Requests V3",
         NotificationManager.IMPORTANCE_HIGH
     )
 }


### PR DESCRIPTION
- if a friend request is initiated, upon accepting the request, the user who sent the friend request should receive a notification letting them know that it was accepted
- should work whether the app is open or not
- should test with two emulators open at once so notifications can be observed in real time
- emulators need to have wifi in order for the notifications to come through (I think?)