### PR TITLE
Messaging - ability to send friend request and block user on UserListScreen

### DIFF
--- a/app/src/main/java/com/example/phinui/components/people/FriendDialogs.kt
+++ b/app/src/main/java/com/example/phinui/components/people/FriendDialogs.kt
@@ -1,0 +1,165 @@
+package com.example.phinui.components.people
+
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import com.example.phinui.ui.theme.Background
+import com.example.phinui.ui.theme.HeaderRed
+import com.example.phinui.ui.theme.NavText
+
+@Composable fun SendFriendRequestDialog(
+    name: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Background,
+        title = {
+            Text("Send friend request?")
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    append("Do you want to send a friend request to ")
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(name)
+                    }
+                    append("?")
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm
+            ) {
+                Text("Send", color = HeaderRed)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Cancel", color = NavText)
+            }
+        }
+    )
+}
+
+@Composable fun AlreadyFriendDialog(
+    name: String,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Background,
+        title = {
+            Text("Already friends")
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(name)
+                    }
+                    append(" is already your friend.")
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Ok", color = HeaderRed)
+            }
+        }
+    )
+}
+
+@Composable fun BlockUserDialog(
+    name: String,
+    isFriend: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Background,
+        title = {
+            Text("Block user?")
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    append("Are you sure you want to block ")
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(name)
+                    }
+
+                    if (isFriend) {
+                        append("? This will also remove them from your friends.")
+                    }
+                    else {
+                        append("?")
+                    }
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm
+            ) {
+                Text("Block", color = HeaderRed)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Cancel", color = NavText)
+            }
+        }
+    )
+}
+
+@Composable fun UnblockUserDialog(
+    name: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Background,
+        title = {
+            Text("Unblock user?")
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    append("Are you sure you want to unblock ")
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(name)
+                    }
+                    append("?")
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm
+            ) {
+                Text("Unblock", color = HeaderRed)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Cancel", color = NavText)
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -62,6 +62,10 @@ import com.google.firebase.firestore.ListenerRegistration
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.phinui.components.people.AlreadyFriendDialog
+import com.example.phinui.components.people.BlockUserDialog
+import com.example.phinui.components.people.SendFriendRequestDialog
+import com.example.phinui.components.people.UnblockUserDialog
 import com.example.phinui.viewmodel.ChatRepositoryViewModel
 
 @Composable
@@ -375,175 +379,70 @@ fun PeopleScreen() {
     }
 
     userToAdd?.let { (uid, name) ->
-        AlertDialog(
-            onDismissRequest = { userToAdd = null },
-            containerColor = Background,
-            title = {
-                Text("Send friend request?")
-            },
-            text = {
-                Text(
-                    buildAnnotatedString {
-                        append("Do you want to send a friend request to ")
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(name)
-                        }
-                        append("?")
+        SendFriendRequestDialog(
+            name = name,
+            onConfirm = {
+                repo.sendFriendRequest(
+                    uid,
+                    myName,
+                    {
+                        userToAdd = null
+                    },
+                    {
+                        message = it.message
+                        userToAdd = null
                     }
                 )
             },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        repo.sendFriendRequest(
-                            uid,
-                            myName,
-                            {
-                                userToAdd = null
-                            },
-                            {
-                                message = it.message
-                                userToAdd = null
-                            }
-                        )
-                    }
-                ) {
-                    Text("Send", color = HeaderRed)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { userToAdd = null }
-                ) {
-                    Text("Cancel", color = NavText)
-                }
-            }
+            onDismiss = { userToAdd = null }
         )
     }
 
     alreadyFriendUser?.let { name ->
-        AlertDialog(
-            onDismissRequest = { alreadyFriendUser = null },
-            containerColor = Background,
-            title = {
-                Text("Already friends")
-            },
-            text = {
-                Text(
-                    buildAnnotatedString {
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(name)
-                        }
-                        append(" is already your friend.")
-                    }
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = { alreadyFriendUser = null }
-                ) {
-                    Text("OK", color = HeaderRed)
-                }
-            }
+        AlreadyFriendDialog(
+            name = name,
+            onDismiss = { alreadyFriendUser = null}
         )
+
     }
 
     userToBlock?.let { (uid, name) ->
         val isFriend = friends.any { (friendUid, _) -> friendUid == uid }
-
-        AlertDialog(
-            onDismissRequest = { userToBlock = null },
-            containerColor = Background,
-            title = {
-                Text("Block user?")
-            },
-            text = {
-                Text(
-                    buildAnnotatedString {
-                        append("Are you sure you want to block ")
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(name)
-                        }
-
-                        if (isFriend) {
-                            append("? This will also remove them from your friends.")
-                        } else {
-                            append("?")
-                        }
+        BlockUserDialog(
+            name = name,
+            isFriend = isFriend,
+            onConfirm = {
+                repo.blockUser(
+                    uid,
+                    {
+                        userToBlock = null
+                    },
+                    {
+                        message = it.message
+                        userToBlock = null
                     }
                 )
             },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        repo.blockUser(
-                            uid,
-                            {
-                                userToBlock = null
-                            },
-                            {
-                                message = it.message
-                                userToBlock = null
-                            }
-                        )
-                    }
-                ) {
-                    Text("Block", color = HeaderRed)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { userToBlock = null }
-                ) {
-                    Text("Cancel", color = NavText)
-                }
-            }
+            onDismiss = { userToBlock = null }
         )
     }
 
     userToUnblock?.let { (uid, name) ->
-        AlertDialog(
-            onDismissRequest = { userToUnblock = null },
-            containerColor = Background,
-            title = {
-                Text("Unblock user?")
-            },
-            text = {
-                Text(
-                    buildAnnotatedString {
-                        append("Are you sure you want to unblock ")
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(name)
-                        }
-                        append("?")
+        UnblockUserDialog(
+            name = name,
+            onConfirm = {
+                repo.unblockUser(
+                    uid,
+                    {
+                        userToUnblock = null
+                    },
+                    {
+                        message = it.message
+                        userToUnblock = null
                     }
                 )
             },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        repo.unblockUser(
-                            uid,
-                            {
-                                userToUnblock = null
-                            },
-                            {
-                                message = it.message
-                                userToUnblock = null
-                            }
-                        )
-                    }
-                ) {
-                    Text("Unblock", color = HeaderRed)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { userToUnblock = null }
-                ) {
-                    Text("Cancel", color = NavText)
-                }
-            }
+            onDismiss = { userToUnblock = null }
         )
     }
 

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.ui.input.pointer.motionEventSpy
 import androidx.lifecycle.viewModelScope
 import com.example.phinui.components.messages.ChatRepository
+import com.example.phinui.components.people.BlockUserDialog
+import com.example.phinui.components.people.SendFriendRequestDialog
 import com.example.phinui.data.friends.FriendRepository
 import com.example.phinui.viewmodel.ChatRepositoryViewModel
 import com.example.phinui.viewmodel.FriendRepositoryViewModel
@@ -53,6 +55,22 @@ fun UserListScreen (
     val currentUserID = chatRepositoryViewModel.currentUserID ?: return
     val friendList = friendRepositoryViewModel.friendsList.value
     var selectedTab by remember { mutableIntStateOf(value = 0) }
+
+    var userToAdd by remember { mutableStateOf<Pair<String, String>?>(null) }
+    var userToBlock by remember { mutableStateOf<Pair<String, String>?>(null) }
+
+    val friendRepository = remember { FriendRepository() }
+    var myName by remember { mutableStateOf("") }
+    val usersDataBase = chatRepositoryViewModel.firebaseFirestoreAuthenticated
+    var message by remember { mutableStateOf<String?>(null) }
+    val generalBlock = false
+
+    LaunchedEffect(Unit) {
+        usersDataBase.collection("users").document(currentUserID).get()
+            .addOnSuccessListener {
+                myName = it.getString("name") ?: ""
+            }
+    }
 
     LaunchedEffect(currentUserID){
         chatRepositoryViewModel.loadMessageRequest(currentUserID)
@@ -155,38 +173,60 @@ fun UserListScreen (
 
                             UserListItem(
                                 user = user,
-//                                trailingContent = {
-//                                    var showMenu by remember { mutableStateOf(false) }
-//                                    Box {
-//                                        IconButton(
-//                                            onClick = { showMenu = !showMenu }
-//                                        ) {
-//                                            Icon(
-//                                                imageVector = Icons.Default.MoreVert,
-//                                                contentDescription = "Options",
-//                                                tint = NavText
-//                                            )
-//                                        }
-//
-//                                        DropdownMenu(
-//                                            expanded = showMenu,
-//                                            onDismissRequest = { showMenu = false },
-//                                            containerColor = Background
-//                                        ) {
-//                                            DropdownMenuItem(
-//                                                text = {
-//                                                    Row(verticalAlignment = Alignment.CenterVertically) {
-//                                                        Icon(Icons.Default.PersonAdd, contentDescription = "Add Friend", tint = NavText)
-//                                                        Spacer(modifier = Modifier.width(8.dp))
-//                                                        Text("Add Friend", color = NavText)
-//                                                    }
-//                                                },
-//                                                onClick = {
-//                                                    showMenu = false
-//                                                    //chatRepositoryViewModel.approveRequest(chatID)
-//                                                }
-//                                            )
-//
+                                trailingContent = {
+                                    var showMenu by remember { mutableStateOf(false) }
+                                    Box {
+                                        IconButton(
+                                            onClick = { showMenu = !showMenu }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.MoreVert,
+                                                contentDescription = "Options",
+                                                tint = NavText
+                                            )
+                                        }
+
+                                        DropdownMenu(
+                                            expanded = showMenu,
+                                            onDismissRequest = { showMenu = false },
+                                            containerColor = Background
+                                        ) {
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(
+                                                            imageVector = Icons.Default.PersonAdd,
+                                                            contentDescription = "Add Friend",
+                                                            tint = NavText
+                                                        )
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Add Friend", color = NavText)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    userToAdd = otherUserID to userName
+                                                }
+                                            )
+
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(
+                                                            imageVector = Icons.Default.Delete,
+                                                            contentDescription = "Block User",
+                                                            tint = HeaderRed
+                                                        )
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Block User", color = HeaderRed)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    userToBlock = otherUserID to userName
+                                                }
+                                            )
+
 //                                            DropdownMenuItem(
 //                                                text = {
 //                                                    Row(verticalAlignment = Alignment.CenterVertically) {
@@ -200,9 +240,9 @@ fun UserListScreen (
 //                                                    //chatRepositoryViewModel.denyRequest(chatID)
 //                                                }
 //                                            )
-//                                        }
-//                                    }
-//                                },
+                                        }
+                                    }
+                                },
                                 onClick = {
                                     navController.navigate(Routes.MESSAGES + "/${user.uid}")
                                 }
@@ -305,6 +345,46 @@ fun UserListScreen (
                 }
             }
         }
+    }
+
+    userToAdd?.let { (uid, name) ->
+        SendFriendRequestDialog(
+            name = name,
+            onConfirm = {
+                friendRepository.sendFriendRequest(
+                    uid,
+                    myName,
+                    {
+                        userToAdd = null
+                    },
+                    {
+                        message = it.message
+                        userToAdd = null
+                    }
+                )
+            },
+            onDismiss = { userToAdd = null }
+        )
+    }
+
+    userToBlock?.let { (uid, name) ->
+        BlockUserDialog(
+            name = name,
+            isFriend = generalBlock,
+            onConfirm = {
+                friendRepository.blockUser(
+                    uid,
+                    {
+                        userToBlock = null
+                    },
+                    {
+                        message = it.message
+                        userToBlock = null
+                    }
+                )
+            },
+            onDismiss = { userToBlock = null }
+        )
     }
 }
 


### PR DESCRIPTION
**New**
- Added a new "FriendDialog" file to house the alert box UI

**Updates**
- PeopleScreen
    - Moved alert dialog boxes to the FriendDialog file
    - Refactored the following code blocks to utilize the new FriendDialog file
        - userToAdd?.let
        - alreadyFriendUser?.let
        - userToBlock?.let
        - userToUnblock?.let
        
- UserListScreen
    - Users can now send friend requests on the General tab
    - Users can now block users on the general tab

**To Do**
- PeopleScreen
    - Match the theme between adding users and sending message requests

- UserListScreen
    - Add unfriend and block functionality on the Friends tab