### PR TITLE
Message notifications

### DIFF
--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -199,8 +199,13 @@ fun PhinNavHost(
                 navArgument("receiverID") {
                     type = NavType.StringType
                 }
+            ),
+            deepLinks = listOf(
+                navDeepLink {
+                    uriPattern = "phin://messages/{receiverID}"
+                }
             )
-            ) { backStackEntry ->
+        ) { backStackEntry ->
             val currentUserID = FirebaseAuth.getInstance().currentUser?.uid ?: ""
             val receiverID = backStackEntry.arguments?.getString("receiverID") ?: ""
 

--- a/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
@@ -44,15 +44,31 @@ class PhinFirebaseMessagingService : FirebaseMessagingService() {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
 
+            "NEW_MESSAGE" ->
+                Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+
             else ->
                 Intent(this, MainActivity::class.java)
-
-
         }
+
+        val notifType = when (type) {
+
+            "FRIEND_REQUEST" ->
+                NotificationType.FRIEND_REQUESTS
+
+            "FRIEND_ACCEPTED" ->
+                NotificationType.FRIEND_REQUESTS
+
+            else ->
+                NotificationType.MESSAGES
+        }
+
 
         NotificationHelper.showNotification(
             context = this,
-            type = NotificationType.FRIEND_REQUESTS,
+            type = notifType,
             title = title,
             body = body,
             intent = launchIntent,

--- a/app/src/main/java/com/example/phinui/notifications/NotificationTypes.kt
+++ b/app/src/main/java/com/example/phinui/notifications/NotificationTypes.kt
@@ -18,5 +18,11 @@ enum class NotificationType(
         "friend_request_channel",
         "Friend Requests V3",
         NotificationManager.IMPORTANCE_HIGH
+    ),
+
+    MESSAGES(
+        "message_channel",
+        "Messages V1",
+        NotificationManager.IMPORTANCE_HIGH
     )
 }


### PR DESCRIPTION
- push notifications should now fire whenever a user receives a new message
- should work whether the app is open or closed
- could potentially change what's written on the notification
- in the future, might look into having the notification not fire if the user is currently on the messaging screen
- as always, testing works best with two emulators running simultaneously