### PR TITLE
Messaging - ability to remove friend and block from the friends tab in the UserListScreen

### DIFF
--- a/app/src/main/java/com/example/phinui/components/people/FriendDialogs.kt
+++ b/app/src/main/java/com/example/phinui/components/people/FriendDialogs.kt
@@ -79,6 +79,36 @@ import com.example.phinui.ui.theme.NavText
     )
 }
 
+@Composable fun ActiveChatDialog(
+    name: String,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Background,
+        title = {
+            Text("Active Chat")
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    append("You already have an active chat with ")
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(name)
+                    }
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Ok", color = HeaderRed)
+            }
+        }
+    )
+}
+
 @Composable fun RemoveFriendDialog(
     name: String,
     onConfirm: () -> Unit,

--- a/app/src/main/java/com/example/phinui/components/people/FriendDialogs.kt
+++ b/app/src/main/java/com/example/phinui/components/people/FriendDialogs.kt
@@ -79,6 +79,45 @@ import com.example.phinui.ui.theme.NavText
     )
 }
 
+@Composable fun RemoveFriendDialog(
+    name: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Background,
+        title = {
+            Text("Remove Friend?")
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    append("Are you sure you want to remove ")
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(name)
+                    }
+                    append(" from your friends?")
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm
+            ) {
+                Text("Remove", color = HeaderRed)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Cancel", color = NavText)
+            }
+        }
+    )
+}
+
 @Composable fun BlockUserDialog(
     name: String,
     isFriend: Boolean,
@@ -105,6 +144,45 @@ import com.example.phinui.ui.theme.NavText
                     else {
                         append("?")
                     }
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm
+            ) {
+                Text("Block", color = HeaderRed)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Cancel", color = NavText)
+            }
+        }
+    )
+}
+
+@Composable fun BlockFriendDialog(
+    name: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Background,
+        title = {
+            Text("Block user?")
+        },
+        text = {
+            Text(
+                buildAnnotatedString {
+                    append("Are you sure you want to block ")
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(name)
+                    }
+                    append("? This will also remove them from your friends")
                 }
             )
         },

--- a/app/src/main/java/com/example/phinui/screens/FriendScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/FriendScreen.kt
@@ -60,6 +60,8 @@ import androidx.compose.material.icons.filled.Block
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.SpanStyle
+import com.example.phinui.components.people.BlockFriendDialog
+import com.example.phinui.components.people.RemoveFriendDialog
 
 @Composable
 fun FriendsScreen(
@@ -337,96 +339,40 @@ fun FriendsScreen(
     }
 
     friendToRemove?.let { (uid, name) ->
-        AlertDialog(
-            onDismissRequest = { friendToRemove = null },
-            containerColor = Background,
-            title = {
-                Text("Remove friend?")
-            },
-            text = {
-                Text(
-                    buildAnnotatedString {
-                        append("Are you sure you want to remove ")
-
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(name)
-                        }
-                        append(" from your friends?")
+        RemoveFriendDialog(
+            name = name,
+            onConfirm = {
+                repo.removeFriend(
+                    friendUid = uid,
+                    onSuccess = {
+                        friendToRemove = null
+                    },
+                    onError = { e ->
+                        message = e.message
+                        friendToRemove = null
                     }
                 )
             },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        repo.removeFriend(
-                            friendUid = uid,
-                            onSuccess = {
-                                friendToRemove = null
-                            },
-                            onError = { e ->
-                                message = e.message
-                                friendToRemove = null
-                            }
-                        )
-                    }
-                ) {
-                    Text("Remove", color = HeaderRed)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { friendToRemove = null }
-                ) {
-                    Text("Cancel", color = NavText)
-                }
-            }
+            onDismiss = { friendToRemove = null }
         )
     }
 
     friendToBlock?.let { (uid, name) ->
-        AlertDialog(
-            onDismissRequest = { friendToBlock = null },
-            containerColor = Background,
-            title = {
-                Text("Block user?")
-            },
-            text = {
-                Text(
-                    buildAnnotatedString {
-                        append("Are you sure you want to block ")
-
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(name)
-                        }
-                        append("? This will also remove them from your friends.")
+        BlockFriendDialog(
+            name = name,
+            onConfirm = {
+                repo.blockUser(
+                    blockedUid = uid,
+                    onSuccess = {
+                        friendToBlock = null
+                    },
+                    onError = { e ->
+                        message = e.message
+                        friendToBlock = null
                     }
                 )
             },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        repo.blockUser(
-                            blockedUid = uid,
-                            onSuccess = {
-                                friendToBlock = null
-                            },
-                            onError = { e ->
-                                message = e.message
-                                friendToBlock = null
-                            }
-                        )
-                    }
-                ) {
-                    Text("Block", color = HeaderRed)
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { friendToBlock = null }
-                ) {
-                    Text("Cancel", color = NavText)
-                }
-            }
+            onDismiss = { friendToBlock = null }
         )
     }
 

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -62,6 +62,7 @@ import com.google.firebase.firestore.ListenerRegistration
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.phinui.components.people.ActiveChatDialog
 import com.example.phinui.components.people.AlreadyFriendDialog
 import com.example.phinui.components.people.BlockUserDialog
 import com.example.phinui.components.people.SendFriendRequestDialog
@@ -448,24 +449,10 @@ fun PeopleScreen() {
 
     val receiverUserName = chatRepositoryViewModel.activeChatUserName.value ?: "Unknown"
     if (chatRepositoryViewModel.showMessageApprovedDialog.value) {
-        AlertDialog(
-            onDismissRequest = {
+        ActiveChatDialog(
+            name = receiverUserName,
+            onDismiss = {
                 chatRepositoryViewModel.showMessageApprovedDialog.value = false
-            },
-            title = {
-                Text("Active Chat")
-            },
-            text = {
-                Text("You already have an active chat with $receiverUserName")
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        chatRepositoryViewModel.showMessageApprovedDialog.value = false
-                    }
-                ) {
-                    Text("Ok")
-                }
             }
         )
     }

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -70,8 +70,6 @@ fun UserListScreen (
     val usersDataBase = chatRepositoryViewModel.firebaseFirestoreAuthenticated
     var message by remember { mutableStateOf<String?>(null) }
 
-    val generalBlock = false
-    val friendBlock = false
 
     LaunchedEffect(Unit) {
         usersDataBase.collection("users").document(currentUserID).get()
@@ -448,7 +446,7 @@ fun UserListScreen (
     userToBlock?.let { (uid, name) ->
         BlockUserDialog(
             name = name,
-            isFriend = generalBlock,
+            isFriend = false,
             onConfirm = {
                 friendRepository.blockUser(
                     uid,

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -25,14 +25,18 @@ import com.example.phinui.components.messages.User
 import com.example.phinui.ui.theme.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.ui.input.pointer.motionEventSpy
 import androidx.lifecycle.viewModelScope
 import com.example.phinui.components.messages.ChatRepository
+import com.example.phinui.components.people.BlockFriendDialog
 import com.example.phinui.components.people.BlockUserDialog
+import com.example.phinui.components.people.RemoveFriendDialog
 import com.example.phinui.components.people.SendFriendRequestDialog
 import com.example.phinui.data.friends.FriendRepository
 import com.example.phinui.viewmodel.ChatRepositoryViewModel
@@ -58,12 +62,16 @@ fun UserListScreen (
 
     var userToAdd by remember { mutableStateOf<Pair<String, String>?>(null) }
     var userToBlock by remember { mutableStateOf<Pair<String, String>?>(null) }
+    var friendToRemove by remember { mutableStateOf<Pair<String, String>?>(null) }
+    var friendToBlock by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     val friendRepository = remember { FriendRepository() }
     var myName by remember { mutableStateOf("") }
     val usersDataBase = chatRepositoryViewModel.firebaseFirestoreAuthenticated
     var message by remember { mutableStateOf<String?>(null) }
+
     val generalBlock = false
+    val friendBlock = false
 
     LaunchedEffect(Unit) {
         usersDataBase.collection("users").document(currentUserID).get()
@@ -127,6 +135,76 @@ fun UserListScreen (
                             if(friend.uid in hideBlockedUsers) return@items
                             UserListItem(
                                 user = friend,
+                                trailingContent = {
+                                    var showMenu by remember { mutableStateOf(false) }
+                                    Box {
+                                        IconButton(
+                                            onClick = { showMenu = !showMenu }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.MoreVert,
+                                                contentDescription = "Options",
+                                                tint = NavText
+                                            )
+                                        }
+
+                                        DropdownMenu(
+                                            expanded = showMenu,
+                                            onDismissRequest = { showMenu = false },
+                                            containerColor = Background
+                                        ) {
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(
+                                                            imageVector = Icons.Default.PersonRemove,
+                                                            contentDescription = "Remove Friend",
+                                                            tint = NavText
+                                                        )
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Remove Friend", color = NavText)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    friendToRemove = friend.uid to friend.name
+                                                }
+                                            )
+
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                                        Icon(
+                                                            imageVector = Icons.Default.Block,
+                                                            contentDescription = "Block User",
+                                                            tint = HeaderRed
+                                                        )
+                                                        Spacer(modifier = Modifier.width(8.dp))
+                                                        Text("Block User", color = HeaderRed)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    showMenu = false
+                                                    friendToBlock = friend.uid to friend.name
+                                                }
+                                            )
+
+//                                            DropdownMenuItem(
+//                                                text = {
+//                                                    Row(verticalAlignment = Alignment.CenterVertically) {
+//                                                        Icon(Icons.Default.Delete, contentDescription = "Delete", tint = HeaderRed)
+//                                                        Spacer(modifier = Modifier.width(8.dp))
+//                                                        Text("Delete", color = HeaderRed)
+//                                                    }
+//                                                },
+//                                                onClick = {
+//                                                    showMenu = false
+//                                                    //chatRepositoryViewModel.denyRequest(chatID)
+//                                                }
+//                                            )
+                                        }
+                                    }
+                                },
                                 onClick = {
                                     navController.navigate(Routes.MESSAGES + "/${friend.uid}")
                                 }
@@ -213,7 +291,7 @@ fun UserListScreen (
                                                 text = {
                                                     Row(verticalAlignment = Alignment.CenterVertically) {
                                                         Icon(
-                                                            imageVector = Icons.Default.Delete,
+                                                            imageVector = Icons.Default.Block,
                                                             contentDescription = "Block User",
                                                             tint = HeaderRed
                                                         )
@@ -386,6 +464,45 @@ fun UserListScreen (
             onDismiss = { userToBlock = null }
         )
     }
+
+    friendToRemove?.let { (uid, name) ->
+        RemoveFriendDialog(
+            name = name,
+            onConfirm = {
+                friendRepository.removeFriend(
+                    friendUid = uid,
+                    onSuccess = {
+                        friendToRemove = null
+                    },
+                    onError = { e ->
+                        message = e.message
+                        friendToRemove = null
+                    }
+                )
+            },
+            onDismiss = { friendToRemove = null }
+        )
+    }
+
+    friendToBlock?.let { (uid, name) ->
+        BlockFriendDialog(
+            name = name,
+            onConfirm = {
+                friendRepository.blockUser(
+                    blockedUid = uid,
+                    onSuccess = {
+                        friendToBlock = null
+                    },
+                    onError = { e ->
+                        message = e.message
+                        friendToBlock = null
+                    }
+                )
+            },
+            onDismiss = { friendToBlock = null }
+        )
+    }
+
 }
 
 @Composable fun UserListItem(

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -73,12 +73,6 @@ class ChatRepositoryViewModel (
             val filteredOtherUserID = filteredParticipants
                 .mapNotNull { it as? String }
                 .firstOrNull{ it != currentUserID }
-
-//            val otherUserName = filteredOtherUserID?.let { uid ->
-//                friendsList.value.firstOrNull{ it.uid == uid }?.name ?: "Unknown"
-//            } ?: "Unknown"
-//
-//            otherUserName.lowercase()
             filteredOtherUserID?.lowercase() ?: ""
         }
     }


### PR DESCRIPTION
**Updates**

- PeopleScreen
    - Moved alert dialog box for active chat alert to the FriendDialog file
    - The active chat alert box now matches the theme of sending a friend request

- FriendsScreen
    - Refactored the following code blocks to utilize the new FriendDialog file
        - friendToRemove?.let
        - friendToBlock?.let


- UserListScreen
    - Users can now send friend requests on the Friends tab
    - Users can now block users on the Friends tab


**To Do**
- Create a deletion method for messages on Friends and General tabs