### PR TITLE
Message Request Notifications

### DIFF
--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -216,7 +216,14 @@ fun PhinNavHost(
             )
         }
 
-        composable (Routes.USERLIST) {
+        composable(
+            Routes.USERLIST,
+            deepLinks = listOf(
+                navDeepLink {
+                    uriPattern = "phin://userlist"
+                }
+            )
+        ) {
             UserListScreen(navController = navController)
         }
 

--- a/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
@@ -12,6 +12,13 @@ import com.google.firebase.messaging.RemoteMessage
 
 class PhinFirebaseMessagingService : FirebaseMessagingService() {
 
+    val deepLinkTypes = setOf(
+        "FRIEND_REQUEST",
+        "FRIEND_ACCEPTED",
+        "NEW_MESSAGE",
+        "MESSAGE_REQUEST"
+    )
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         // send the token to the database
@@ -32,26 +39,14 @@ class PhinFirebaseMessagingService : FirebaseMessagingService() {
         val type = remoteMessage.data["type"]
         val uri = remoteMessage.data["uri"]
 
-        val launchIntent = when (type) {
-
-            "FRIEND_REQUEST" ->
+        val launchIntent =
+            if (type in deepLinkTypes) {
                 Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
-
-            "FRIEND_ACCEPTED" ->
-                Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                }
-
-            "NEW_MESSAGE" ->
-                Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                }
-
-            else ->
+            } else {
                 Intent(this, MainActivity::class.java)
-        }
+            }
 
         val notifType = when (type) {
 

--- a/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/phinui/notifications/FirebaseMessagingService.kt
@@ -16,7 +16,8 @@ class PhinFirebaseMessagingService : FirebaseMessagingService() {
         "FRIEND_REQUEST",
         "FRIEND_ACCEPTED",
         "NEW_MESSAGE",
-        "MESSAGE_REQUEST"
+        "MESSAGE_REQUEST",
+        "ACCEPT_MESSAGE_REQUEST"
     )
 
     override fun onNewToken(token: String) {

--- a/app/src/main/java/com/example/phinui/screens/RegisterScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/RegisterScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.font.FontWeight
+import com.example.phinui.notifications.FCMTokenManager
 import com.example.phinui.ui.components.AuthHeader
 
 @Composable
@@ -165,6 +166,7 @@ fun RegisterScreen(
                                 .set(userProfile)
                                 .addOnSuccessListener {
                                     loading = false
+                                    FCMTokenManager.registerToken()
                                     onRegisterSuccess()
                                 }
                                 .addOnFailureListener { e ->


### PR DESCRIPTION
Added push notifications for message requests that are sent and message requests that are accepted. Also changed the code to register FCM token if the user is registering an account for the first time. 

For testing I would recommend:
- using two emulators simultaneously
- if you're testing between two accounts that already have messageRequestAccepted = true, manually change to false in firestore (unless you want to create a new user, that works too, just becomes a longer process)
- if you're having issues with the emulator's internet strength, try going to extended controls -> cellular tab and changing the signal strength to great