### PR TITLE
Messaging - Fix request bug

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -57,7 +57,8 @@ class ChatRepository {
                 "lastMessage" to "",
                 "lastTimestamp" to messageProperties.currentTime,
                 "participants" to listOf(senderUserID, receiverUserID),
-                "messageRequestApproved" to false
+                "messageRequestApproved" to false,
+                "senderID" to senderUserID
             )
         ).addOnFailureListener {
             messageProperties.chatReference.set(
@@ -65,7 +66,8 @@ class ChatRepository {
                     "lastMessage" to "",
                     "lastTimestamp" to messageProperties.currentTime,
                     "participants" to listOf(senderUserID, receiverUserID),
-                    "messageRequestApproved" to false
+                    "messageRequestApproved" to false,
+                    "senderID" to senderUserID
                 )
             )
         }
@@ -105,6 +107,10 @@ class ChatRepository {
                 if (error != null || snapshot == null) return@addSnapshotListener
                 val messageRequest = snapshot.documents.mapNotNull { doc ->
                     val data = doc.data ?: return@mapNotNull null
+
+                    val senderID = data["senderID"] as? String
+                    if (senderID == userID) return@mapNotNull null
+
                     data + mapOf("chatID" to doc.id)
                 }
                 onResult(messageRequest)


### PR DESCRIPTION
Issue:
- Whenever a user sends a message request to a target user, the target user does receive the request, but the sender automatically receives a request from the target user even though the target user never sent one out.

Fix:
- The user sending a message request will no longer automatically receive a message request from the target user. A check has been placed to ensure the Requests tab is not listening for all chats with only "messageRequestAccepted = false", but instead also checks who sent the request.