### PR TITLE
new message notifs conditional

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.SetOptions
 
 class ChatRepository {
 
@@ -150,6 +151,21 @@ class ChatRepository {
                 }
                 onResult(chats)
             }
+    }
+
+    fun setActiveChat(userID: String, chatID: String?) {
+        val userRef = database
+            .collection("users")
+            .document(userID)
+
+        userRef.set(
+            mapOf(
+                "activeChatID" to chatID,
+                "lastActive" to com.google.firebase.Timestamp.now()
+            ),
+            SetOptions.merge()
+        )
+
     }
 
     data class MessageInfo(

--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -65,6 +65,19 @@ fun MessagesScreen(
         userListViewModel.loadSelectedUser(receiverUserID)
     }
 
+    val chatID = chatRepository.getChatID(senderUserID, receiverUserID)
+
+    LaunchedEffect(chatID) {
+        chatRepositoryViewModel.onChatOpened(senderUserID, chatID)
+    }
+
+
+    DisposableEffect(Unit) {
+        onDispose {
+            chatRepositoryViewModel.onChatClosed(senderUserID)
+        }
+    }
+
     if (initialChatOpen.value) {
         //Automatic scroll effect
         LaunchedEffect(messages) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -177,4 +177,12 @@ class ChatRepositoryViewModel (
         chatRepository.deleteMessage(chatID, messageID)
     }
 
+    fun onChatOpened(userID: String, chatID: String) {
+        chatRepository.setActiveChat(userID, chatID)
+    }
+
+    fun onChatClosed(userID: String) {
+        chatRepository.setActiveChat(userID, null)
+    }
+
 }

--- a/functions/newMessageNotif.js
+++ b/functions/newMessageNotif.js
@@ -45,11 +45,28 @@ exports.sendNewMessageNotification = onDocumentUpdated(
         const fcmToken = accepterData && accepterData.fcmToken ?
                 accepterData.fcmToken : null;
 
+        const activeChatID = accepterData ? accepterData.activeChatID : null;
+        const lastActive = accepterData ? accepterData.lastActive : null;
+
         if (!fcmToken) {
           console.log("No FCM token for user: ", accepterId);
           return null;
         } else {
           console.log("FCM token for messaging: ", fcmToken);
+        }
+
+        const chatId = event.params.requestId;
+        const now = Date.now();
+        const lastActiveTime =
+          lastActive && typeof lastActive.toMillis === "function" ?
+          lastActive.toMillis() : 0;
+        const isInChat = activeChatID === chatId;
+        const isActive = (now - lastActiveTime) < 60000;
+
+        // only send if user is not on the chat screen
+        if (isInChat && isActive) {
+          console.log("User is currently in this chat. Skipping notification");
+          return null;
         }
 
         await admin.messaging().send({


### PR DESCRIPTION
New Message Notifications should only be sent if the user is not currently on the chat screen. Two new fields get added to the user's firestore document when they open a chat: activeChatID and lastActive. The cloud function should be able to detect if the chat is open or not and decides if it should trigger the notif. 