### PR TITLE
Fix add-event-to-calendar from events screen

### DIFF
--- a/app/src/main/java/com/example/phinui/data/calendar/FirebaseCalendarRepository.kt
+++ b/app/src/main/java/com/example/phinui/data/calendar/FirebaseCalendarRepository.kt
@@ -25,23 +25,23 @@ class FirebaseCalendarRepository(
             .collection("events")
 
     suspend fun saveEvent(event: CalendarEvent) {
-        eventsCollection()
-            .document(event.id)
-            .set(
-                mapOf(
-                    "id" to event.id,
-                    "title" to event.title,
-                    "start" to event.start,
-                    "end" to event.end,
-                    "location" to event.location,
-                    "reminderMinutes" to event.reminderMinutes,
-                    "description" to event.description,
-                    "isAllDay" to event.isAllDay,
-                    "colorHex" to event.colorHex,
-                    "source" to event.source.name
-                )
+        val docRef = eventsCollection().document()
+        val safeEvent = event.copy(id = docRef.id)
+
+        docRef.set(
+            mapOf(
+                "id" to safeEvent.id,
+                "title" to safeEvent.title,
+                "start" to safeEvent.start,
+                "end" to safeEvent.end,
+                "location" to safeEvent.location,
+                "reminderMinutes" to safeEvent.reminderMinutes,
+                "description" to safeEvent.description,
+                "isAllDay" to safeEvent.isAllDay,
+                "colorHex" to safeEvent.colorHex,
+                "source" to safeEvent.source.name
             )
-            .await()
+        ).await()
     }
 
     suspend fun deleteEvent(eventId: String) {

--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -290,8 +290,11 @@ fun PhinNavHost(
                 //events = allEvents,
                 events = schoolEvents,
                 onEventClick = { event ->
-                    val googleEvents = calendarViewModel.eventsGroupedByDate.values.flatten()
-                    val existsLocally = savedEvents.any { sameCalendarEvent(it, event) }
+                    val allCalendarEvents = calendarViewModel.eventsGroupedByDate.values.flatten()
+                    val googleEvents = allCalendarEvents.filter { it.source == CalendarSource.GOOGLE }
+                    val localEvents = allCalendarEvents.filter { it.source == CalendarSource.LOCAL }
+
+                    val existsLocally = localEvents.any { sameCalendarEvent(it, event) }
                     val existsInGoogle = googleEvents.any { sameCalendarEvent(it, event) }
 
                     if (existsInGoogle) {


### PR DESCRIPTION
- Fixed add-to-calendar bug after Firebase integration
- fixed the calendar event saving by generating unique document IDs 

Now you should be able to add events to your calendar again from the events screen like usual