### PR TITLE
Messaging - Date and time picker for study session invite

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -5,6 +5,7 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
+import com.google.firebase.Timestamp
 
 class ChatRepository {
 
@@ -56,7 +57,9 @@ class ChatRepository {
         senderUserID: String,
         receiverUserID: String,
         studySessionTitle: String,
-        studySessionDescription: String
+        studySessionDescription: String,
+        startTime: Timestamp,
+        endTime: Timestamp
     ) {
         val messageProperties = messageInfoHelper(senderUserID, receiverUserID)
 
@@ -67,6 +70,8 @@ class ChatRepository {
             "description" to studySessionDescription,
             "timestamp" to messageProperties.currentTime,
             "deleted" to false,
+            "startTime" to startTime,
+            "endTime" to endTime,
             "participants" to mapOf(
                 senderUserID to "ACCEPTED",
                 receiverUserID to "PENDING"

--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -1,6 +1,7 @@
 package com.example.phinui.ui.screens
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
@@ -8,33 +9,58 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Icon
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TimeInput
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.*
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 //import androidx.compose.ui.input.pointer.motionEventSpy
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.phinui.components.messages.ChatRepository
 import com.example.phinui.ui.theme.*
 import com.example.phinui.viewmodel.ChatRepositoryViewModel
 import com.example.phinui.viewmodel.UserListViewModel
+import com.google.firebase.Timestamp
+import java.time.*
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 
 @Composable
@@ -48,14 +74,31 @@ fun MessagesScreen(
     val chatRepositoryViewModel = remember { ChatRepositoryViewModel() }
     var messageText by remember { mutableStateOf("") }
     var messages by remember { mutableStateOf(listOf<Map<String, Any>>()) }
+
     val selectedUser = userListViewModel.selectedUser
     val isLoadingStatus = userListViewModel.isLoading
     val autoScrollState = rememberLazyListState()
     val initialChatOpen = remember { mutableStateOf(true) }
+
     var selectedMessage = remember { mutableStateOf<Map<String, Any>?>(null) }
     var showDeleteDialog = remember { mutableStateOf(false) }
     //val chatID = chatRepository.getChatID(senderUserID, receiverUserID)
     val chatID = chatRepositoryViewModel.callGetChatID(senderUserID, receiverUserID)
+
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showStartTimePicker by remember { mutableStateOf(false) }
+    var showEndTimePicker by remember { mutableStateOf(false) }
+
+    var selectedStudyDate by remember { mutableStateOf("") }
+    var selectedStudyStartTime by remember { mutableStateOf<LocalTime?>(null) }
+    var selectedStudyEndTime by remember { mutableStateOf<LocalTime?>(null)}
+//    var selectedStudyStartHour by remember { mutableStateOf<Int?>(null) }
+//    var selectedStudyStartMinute by remember { mutableStateOf<Int?>(null) }
+//    var selectedStudyEndHour by remember { mutableStateOf<Int?>(null) }
+//    var selectedStudyEndMinute by remember { mutableStateOf<Int?>(null) }
+
+    //var selectedStudyTime by remember { mutableStateOf("") }
+    //var eventDate by remember { mutableStateOf("") }
 
     LaunchedEffect(selectedUser) {
         selectedUser?.name?.let { userName ->
@@ -359,17 +402,108 @@ fun MessagesScreen(
                                 onValueChange = { studySessionDescription = it },
                                 label = { Text("Description") }
                             )
+
+                            Spacer(modifier = Modifier.height(8.dp))
+                            
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { showDatePicker = true }
+                                    .padding(12.dp)
+                            ) {
+                                Icon(Icons.Default.DateRange, contentDescription = "Date")
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text("Select date")
+                            }
+
+                            if (showDatePicker) {
+                                EventDatePickerDialog(
+                                    initialDate = selectedStudyDate,
+                                    onDismiss = { showDatePicker = false },
+                                    onConfirm = { date ->
+                                        selectedStudyDate = date
+                                        showDatePicker = false
+                                    }
+                                )
+                            }
+
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { showStartTimePicker = true }
+                                    .padding(12.dp)
+                            ) {
+                                Icon(Icons.Default.AccessTime, contentDescription = "Start time")
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text("Select start time")
+                            }
+
+                            if (showStartTimePicker) {
+                                EventTimePickerDialog (
+                                    title = "Start Time",
+                                    initialTime = selectedStudyStartTime,
+                                    onDismiss = { showStartTimePicker = false },
+                                    onConfirm = { selectedTime ->
+                                        selectedStudyStartTime = selectedTime
+                                        showStartTimePicker = false
+                                    }
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.width(8.dp))
+
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { showEndTimePicker = true }
+                                    .padding(12.dp)
+                            ) {
+                                Icon(Icons.Default.AccessTime, contentDescription = "End time")
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text("Select end time")
+                            }
+
+                            if (showEndTimePicker) {
+                                EventTimePickerDialog(
+                                    title = "End Time",
+                                    initialTime = selectedStudyEndTime,
+                                    onDismiss = { showEndTimePicker = false },
+                                    onConfirm = { selectedTime ->
+                                        selectedStudyEndTime = selectedTime
+                                        showEndTimePicker = false
+                                    }
+                                )
+                            }
                         }
                     },
 
                     confirmButton = {
                         Button(
                             onClick = {
+                                if(selectedStudyStartTime == null || selectedStudyEndTime == null) {
+                                    return@Button
+                                }
+
+                                val studyStartTime = convertToCalendarTimestamp(
+                                    selectedStudyDate,
+                                    selectedStudyStartTime!!
+                                )
+
+                                val studyEndTime = convertToCalendarTimestamp(
+                                    selectedStudyDate,
+                                    selectedStudyEndTime!!
+                                )
+
                                 chatRepositoryViewModel.callSendStudySessionInvitation(
                                     senderUserID = senderUserID,
                                     receiverUserID = receiverUserID,
                                     studySessionTitle = studySessionTitle,
-                                    studySessionDescription = studySessionDescription
+                                    studySessionDescription = studySessionDescription,
+                                    startTime = studyStartTime,
+                                    endTime = studyEndTime
                                 )
 
                                 showStudySessionInviteDialog = false
@@ -392,3 +526,251 @@ fun MessagesScreen(
         }
     }
 }
+
+fun convertToCalendarTimestamp(selectedStudyDate: String, selectedStudyTime: LocalTime): Timestamp {
+    val localDate = LocalDate.parse(selectedStudyDate)
+
+    val dateTime = LocalDateTime.of(localDate, selectedStudyTime)
+    val instant = dateTime.atZone(ZoneId.systemDefault()).toInstant()
+
+    return Timestamp(instant.epochSecond, instant.nano)
+}
+
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+private fun EventDatePickerDialog(
+    initialDate: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit
+) {
+    val accentRed = Color(0xFFFF1F1F)
+
+    val initialMillis = remember(initialDate) {
+        parseIsoDateToMillis(initialDate)
+    }
+
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = initialMillis
+    )
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = {
+                    val millis = datePickerState.selectedDateMillis
+                    if (millis != null) {
+                        onConfirm(formatMillisToIsoDate(millis))
+                    }
+                },
+                enabled = datePickerState.selectedDateMillis != null,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = accentRed,
+                    contentColor = Color.White
+                ),
+                shape = RoundedCornerShape(14.dp)
+            ) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel", color = accentRed)
+            }
+        },
+        colors = DatePickerDefaults.colors(
+            containerColor = Color.White
+        )
+    ) {
+        DatePicker(
+            state = datePickerState,
+            showModeToggle = true,
+            colors = DatePickerDefaults.colors(
+                containerColor = Color.White,
+                titleContentColor = Color.Black,
+                headlineContentColor = Color.Black,
+                weekdayContentColor = Color.DarkGray,
+                subheadContentColor = Color.DarkGray,
+                selectedDayContainerColor = accentRed,
+                selectedDayContentColor = Color.White,
+                todayDateBorderColor = accentRed,
+                todayContentColor = accentRed,
+                selectedYearContainerColor = accentRed,
+                selectedYearContentColor = Color.White,
+                dayContentColor = Color.Black,
+                disabledDayContentColor = Color.LightGray
+            )
+        )
+    }
+}
+
+private fun parseIsoDateToMillis(date: String): Long? {
+    return try {
+        val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        formatter.timeZone = TimeZone.getTimeZone("UTC")
+        formatter.parse(date)?.time
+    } catch (_: Exception) {
+        null
+    }
+}
+
+private fun formatMillisToIsoDate(millis: Long): String {
+    val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    formatter.timeZone = TimeZone.getTimeZone("UTC")
+    return formatter.format(Date(millis))
+}
+
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+private fun EventTimePickerDialog(
+    title: String,
+    initialTime: LocalTime?,
+    onDismiss: () -> Unit,
+    onConfirm: (LocalTime) -> Unit
+) {
+    val initialHour24 = remember(initialTime) {
+        initialTime?.hour ?: 9
+    }
+
+    val initialMinute = remember(initialTime) {
+        initialTime?.minute ?: 0
+    }
+
+    val timePickerState = rememberTimePickerState(
+        initialHour = initialHour24,
+        initialMinute = initialMinute,
+        is24Hour = false
+    )
+
+    var showDial by rememberSaveable { mutableStateOf(false) }
+
+    val accentRed = Color(0xFFFF1F1F)
+    val cardColor = Color(0xFFF7F5F2)
+    val titleColor = Color(0xFF111111)
+    val bodyColor = Color(0xFF444444)
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.DialogProperties(
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Surface(
+            shape = RoundedCornerShape(28.dp),
+            color = cardColor,
+            shadowElevation = 10.dp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 28.dp, vertical = 22.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = titleColor,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    IconButton(onClick = { showDial = !showDial }) {
+                        Icon(
+                            imageVector = if (showDial) Icons.Outlined.Edit else Icons.Outlined.Schedule,
+                            contentDescription = null,
+                            tint = accentRed
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = if (showDial) "Dial picker" else "Enter time",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = bodyColor
+                )
+
+                Spacer(modifier = Modifier.height(18.dp))
+
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (showDial) {
+                        TimePicker(state = timePickerState)
+                    } else {
+                        TimeInput(state = timePickerState)
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text("Cancel", color = accentRed)
+                    }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Button(
+                        onClick = {
+                            onConfirm(
+                                LocalTime.of(
+                                    timePickerState.hour,
+                                    timePickerState.minute
+                                )
+                            )
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = accentRed,
+                            contentColor = Color.White
+                        ),
+                        shape = RoundedCornerShape(14.dp)
+                    ) {
+                        Text("OK")
+                    }
+                }
+            }
+        }
+    }
+}
+
+//private fun convertTo24Hour(time12: String): String {
+//    val parts = time12.trim().split(" ")
+//    val time = parts[0]
+//    val period = parts[1]
+//
+//    val (hourStr, minuteStr) = time.split(":")
+//    var hour = hourStr.toInt()
+//
+//    if (period == "PM" && hour != 12) {
+//        hour += 12
+//    } else if (period == "AM" && hour == 12) {
+//        hour = 0
+//    }
+//
+//    return String.format("%02d:%02d", hour, minuteStr.toInt())
+//}
+//
+//private fun formatTo12Hour(hour24: Int, minute: Int): String {
+//    val period = if (hour24 >= 12) "PM" else "AM"
+//    val hour12 = when {
+//        hour24 == 0 -> 12
+//        hour24 > 12 -> hour24 - 12
+//        else -> hour24
+//    }
+//    return String.format("%d:%02d %s", hour12, minute, period)
+//}
+
+//private fun isValidDate(date: String): Boolean {
+//    val regex = Regex("""\d{4}-\d{2}-\d{2}""")
+//    return regex.matches(date)
+//}

--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -54,7 +54,8 @@ fun MessagesScreen(
     val initialChatOpen = remember { mutableStateOf(true) }
     var selectedMessage = remember { mutableStateOf<Map<String, Any>?>(null) }
     var showDeleteDialog = remember { mutableStateOf(false) }
-    val chatID = chatRepository.getChatID(senderUserID, receiverUserID)
+    //val chatID = chatRepository.getChatID(senderUserID, receiverUserID)
+    val chatID = chatRepositoryViewModel.callGetChatID(senderUserID, receiverUserID)
 
     LaunchedEffect(selectedUser) {
         selectedUser?.name?.let { userName ->
@@ -62,7 +63,8 @@ fun MessagesScreen(
     }
 
     LaunchedEffect(senderUserID, receiverUserID) {
-        chatRepository.checkForNewMessage(senderUserID, receiverUserID) {
+        //chatRepository.checkForNewMessage(senderUserID, receiverUserID) {
+        chatRepositoryViewModel.callCheckForNewMessage(senderUserID, receiverUserID) {
                 newMessages ->
             messages = newMessages
         }
@@ -114,7 +116,8 @@ fun MessagesScreen(
                 confirmButton = {
                     TextButton(onClick = {
                         val message = selectedMessage.value ?: return@TextButton
-                        val chatID = chatRepository.getChatID(senderUserID, receiverUserID)
+                        //val chatID = chatRepository.getChatID(senderUserID, receiverUserID)
+                        //val chatID = chatRepositoryViewModel.callGetChatID(senderUserID, receiverUserID)
                         chatRepositoryViewModel.onDeleteMessage(
                             message = message,
                             chatID = chatID
@@ -227,7 +230,7 @@ fun MessagesScreen(
                                                     Row {
                                                         Button(
                                                             onClick = {
-                                                                chatRepository.respondStudySessionInvitation(
+                                                                chatRepositoryViewModel.callRespondStudySessionInvitation(
                                                                     chatID = chatID,
                                                                     messageID = messageID,
                                                                     senderUserID = senderUserID,
@@ -242,7 +245,7 @@ fun MessagesScreen(
 
                                                         Button(
                                                             onClick = {
-                                                                chatRepository.respondStudySessionInvitation(
+                                                                chatRepositoryViewModel.callRespondStudySessionInvitation(
                                                                     chatID = chatID,
                                                                     messageID = messageID,
                                                                     senderUserID = senderUserID,
@@ -312,7 +315,8 @@ fun MessagesScreen(
 
             Button(onClick = {
                 if (messageText.isNotBlank()) {
-                    chatRepository.sendMessage(
+                    //chatRepository.sendMessage(
+                    chatRepositoryViewModel.callSendMessage(
                         senderUserID,
                         receiverUserID,
                         messageText
@@ -361,7 +365,7 @@ fun MessagesScreen(
                     confirmButton = {
                         Button(
                             onClick = {
-                                chatRepository.sendStudySessionInvitation(
+                                chatRepositoryViewModel.callSendStudySessionInvitation(
                                     senderUserID = senderUserID,
                                     receiverUserID = receiverUserID,
                                     studySessionTitle = studySessionTitle,

--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.AlarmOff
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.outlined.Edit
@@ -58,6 +59,7 @@ import com.example.phinui.viewmodel.UserListViewModel
 import com.google.firebase.Timestamp
 import java.time.*
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -198,6 +200,8 @@ fun MessagesScreen(
                 val isDeleted = message["deleted"] as? Boolean ?: false
                 val messageID = message["messageID"] as? String ?: ""
                 val chatID = message["chatID"] as? String ?: ""
+                val startTime = message["startTime"] as? Timestamp
+                val endTime = message["endTime"] as? Timestamp
                 val isMyMessage = senderID == senderUserID
 
                 val studySessionTitle = message["title"] as? String ?: "Study Session"
@@ -205,6 +209,15 @@ fun MessagesScreen(
                 val participants = message["participants"] as? Map<String, String> ?: emptyMap()
                 val myStatus = participants[senderUserID] ?: "PENDING"
                 val receiverStatus = participants[receiverUserID] ?: "PENDING"
+
+                val convertDate = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+                val convertTime = SimpleDateFormat("h:mm a", Locale.getDefault())
+                val displayDate = startTime?.toDate()?.let { convertDate.format(it) } ?: ""
+                val displayStartTime = startTime?.toDate()?.let { convertTime.format(it) } ?: ""
+                val displayEndTime = endTime?.toDate()?.let {convertTime.format(it) } ?: ""
+
+//                val displayStartTime = startTime?.toDate()?.toString() ?: ""
+//                val displayEndTime = endTime?.toDate()?.toString() ?: ""
 
                 Row(
                     modifier = Modifier
@@ -264,6 +277,12 @@ fun MessagesScreen(
                                                 text = studySessionDescription
                                             )
                                         }
+
+                                        Spacer(modifier = Modifier.height(8.dp))
+
+                                        Text("Date: " + displayDate)
+                                        Text("Start time: " + displayStartTime)
+                                        Text("End time: " + displayEndTime)
 
                                         Spacer(modifier = Modifier.height(8.dp))
 
@@ -381,6 +400,8 @@ fun MessagesScreen(
             if (showStudySessionInviteDialog) {
                 var studySessionTitle by remember { mutableStateOf("") }
                 var studySessionDescription by remember {mutableStateOf("")}
+                val amPMTime = DateTimeFormatter.ofPattern("h:mm a", Locale.getDefault())
+                var emptyFieldChecker by remember { mutableStateOf<String?>(null) }
 
                 AlertDialog(
                     onDismissRequest = { showStudySessionInviteDialog = false },
@@ -404,7 +425,7 @@ fun MessagesScreen(
                             )
 
                             Spacer(modifier = Modifier.height(8.dp))
-                            
+
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
                                 modifier = Modifier
@@ -414,7 +435,11 @@ fun MessagesScreen(
                             ) {
                                 Icon(Icons.Default.DateRange, contentDescription = "Date")
                                 Spacer(modifier = Modifier.width(8.dp))
-                                Text("Select date")
+                                Text(
+                                    text =
+                                        if (selectedStudyDate.isNotEmpty()) { selectedStudyDate }
+                                        else { "Select date" }
+                                )
                             }
 
                             if (showDatePicker) {
@@ -437,7 +462,9 @@ fun MessagesScreen(
                             ) {
                                 Icon(Icons.Default.AccessTime, contentDescription = "Start time")
                                 Spacer(modifier = Modifier.width(8.dp))
-                                Text("Select start time")
+                                Text(
+                                    text = selectedStudyStartTime?.format(amPMTime) ?: "Select start time"
+                                )
                             }
 
                             if (showStartTimePicker) {
@@ -461,9 +488,11 @@ fun MessagesScreen(
                                     .clickable { showEndTimePicker = true }
                                     .padding(12.dp)
                             ) {
-                                Icon(Icons.Default.AccessTime, contentDescription = "End time")
+                                Icon(Icons.Default.AlarmOff, contentDescription = "End time")
                                 Spacer(modifier = Modifier.width(8.dp))
-                                Text("Select end time")
+                                Text(
+                                    text = selectedStudyEndTime?.format(amPMTime) ?: "Select end time"
+                                )
                             }
 
                             if (showEndTimePicker) {
@@ -477,14 +506,58 @@ fun MessagesScreen(
                                     }
                                 )
                             }
+
+                            emptyFieldChecker?.let{
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = it,
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
                         }
                     },
 
                     confirmButton = {
                         Button(
                             onClick = {
-                                if(selectedStudyStartTime == null || selectedStudyEndTime == null) {
-                                    return@Button
+                                // studySessionDescription is optional.
+                                val eventStartTime = selectedStudyStartTime
+                                val eventEndTime = selectedStudyEndTime
+
+                                when {
+                                    studySessionTitle.isBlank() -> {
+                                        emptyFieldChecker = "Please enter a title"
+                                        return@Button
+                                    }
+
+                                    selectedStudyDate.isBlank() -> {
+                                        emptyFieldChecker = "Please select a date"
+                                        return@Button
+
+                                    }
+
+                                    eventStartTime == null -> {
+                                        emptyFieldChecker = "Please select a start time"
+                                        return@Button
+
+                                    }
+
+                                    eventEndTime == null -> {
+                                        emptyFieldChecker = "Please select an end time"
+                                        return@Button
+
+                                    }
+
+                                    eventEndTime <= eventStartTime -> {
+                                        emptyFieldChecker = "End time must be after start time"
+                                        return@Button
+                                    }
+
+                                    else -> {
+                                        emptyFieldChecker = null
+                                    }
+
                                 }
 
                                 val studyStartTime = convertToCalendarTimestamp(

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -50,6 +50,14 @@ class ChatRepositoryViewModel (
         }
     }
 
+    fun callGetChatID(firstUserID: String, secondUserID: String): String {
+        return chatRepository.getChatID(firstUserID, secondUserID)
+    }
+
+    fun callCheckForNewMessage(senderUserID: String, receiverUserID: String, newMessage: (List<Map<String, Any>>) -> Unit) {
+        chatRepository.checkForNewMessage(senderUserID, receiverUserID, newMessage)
+    }
+
     val getGeneralChats = derivedStateOf {
         val friendIDs = friendsList.value.map { it.uid }.toSet()
 
@@ -154,6 +162,28 @@ class ChatRepositoryViewModel (
                 }
             }
         }
+    }
+
+    fun callSendMessage(senderUserID: String, receiverUserID: String, messageText: String) {
+        chatRepository.sendMessage(senderUserID, receiverUserID, messageText)
+    }
+
+    fun callSendStudySessionInvitation(
+        senderUserID: String,
+        receiverUserID: String,
+        studySessionTitle: String,
+        studySessionDescription: String
+    ) {
+        chatRepository.sendStudySessionInvitation(senderUserID, receiverUserID, studySessionTitle, studySessionDescription)
+    }
+
+    fun callRespondStudySessionInvitation(
+        chatID: String,
+        messageID: String,
+        senderUserID: String,
+        invitationResponse: String
+    ) {
+        chatRepository.respondStudySessionInvitation(chatID, messageID, senderUserID, invitationResponse)
     }
 
     fun approveRequest(chatID: String) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -10,6 +10,7 @@ import com.example.phinui.components.messages.UserListRepository
 import com.example.phinui.data.friends.FriendRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.Timestamp
 
 class ChatRepositoryViewModel (
     private val chatRepository: ChatRepository = ChatRepository(),
@@ -172,9 +173,12 @@ class ChatRepositoryViewModel (
         senderUserID: String,
         receiverUserID: String,
         studySessionTitle: String,
-        studySessionDescription: String
+        studySessionDescription: String,
+        startTime: Timestamp,
+        endTime: Timestamp
+
     ) {
-        chatRepository.sendStudySessionInvitation(senderUserID, receiverUserID, studySessionTitle, studySessionDescription)
+        chatRepository.sendStudySessionInvitation(senderUserID, receiverUserID, studySessionTitle, studySessionDescription, startTime, endTime)
     }
 
     fun callRespondStudySessionInvitation(


### PR DESCRIPTION
**Update**
- Refactored MessagesScreen.kt to use ChatRepositoryViewModel.kt instead of ChatRepository.kt
    - added a few "call" functions in ChatRepositoryViewModel.kt

**New**
- Copied the date and time picker code and logic from AddEventScreen.kt
- The sender user will now get to select the date, start time, and end time for their invite
- The sender user must provide a value for title, date, start time, and end time. Description is left as optional
    - user will receive an error message if any fields are left empty (akin to when creating an event on the calendar screen)
    - each field has an error message check except for the description
- The receiving user will see a message with the title, description (if applicable), date, start time, and end time

**To Test**
1. Go to messages
2. Select a chat
3. Click on calendar icon next to the send button (bottom right)
4. Fill out fields
    - Try out different combinations of leaving certain fields empty to see the different error messages.

**To Do**
- Auto create the event in both user's local calendar
- Update UI
- ~~Add a time picker for the invitation~~
- ~~Add a date picker for the invitation~~
- ~~Either require something to be entered in both the title and description text fields, or populate with default information~~
    - ~~Default fields could be "Study Session Invite" for title, and "Hey! Want to study together?" for description~~