### PR TITLE
Link google calendar sign to user's account

### DIFF
--- a/app/src/main/java/com/example/phinui/data/authorization/GoogleCalendarSessionStorage.kt
+++ b/app/src/main/java/com/example/phinui/data/authorization/GoogleCalendarSessionStorage.kt
@@ -9,30 +9,28 @@ class GoogleCalendarSessionStorage(context: Context) {
         Context.MODE_PRIVATE
     )
 
-    companion object {
-        private const val KEY_CONNECTED = "connected"
-        private const val KEY_USER_EMAIL = "user_email"
-    }
+    private fun connectedKey(firebaseUid: String): String = "connected_$firebaseUid"
+    private fun emailKey(firebaseUid: String): String = "user_email_$firebaseUid"
 
-    fun saveSession(userEmail: String?) {
+    fun saveSession(firebaseUid: String, userEmail: String?) {
         sessionPreference.edit()
-            .putBoolean(KEY_CONNECTED, true)
-            .putString(KEY_USER_EMAIL, userEmail)
+            .putBoolean(connectedKey(firebaseUid), true)
+            .putString(emailKey(firebaseUid), userEmail)
             .apply()
     }
 
-    fun isConnected(): Boolean {
-        return sessionPreference.getBoolean(KEY_CONNECTED, false)
+    fun isConnected(firebaseUid: String): Boolean {
+        return sessionPreference.getBoolean(connectedKey(firebaseUid), false)
     }
 
-    fun getUserEmail(): String? {
-        return sessionPreference.getString(KEY_USER_EMAIL, null)
+    fun getUserEmail(firebaseUid: String): String? {
+        return sessionPreference.getString(emailKey(firebaseUid), null)
     }
 
-    fun clearSession() {
+    fun clearSession(firebaseUid: String) {
         sessionPreference.edit()
-            .remove(KEY_CONNECTED)
-            .remove(KEY_USER_EMAIL)
+            .remove(connectedKey(firebaseUid))
+            .remove(emailKey(firebaseUid))
             .apply()
     }
 }

--- a/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendarFirebaseRepository.kt
+++ b/app/src/main/java/com/example/phinui/data/calendar/GoogleCalendarFirebaseRepository.kt
@@ -1,0 +1,51 @@
+package com.example.phinui.data.calendar
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FieldValue
+import kotlinx.coroutines.tasks.await
+
+data class GoogleCalendarIntegration(
+    val connected: Boolean = false,
+    val googleEmail: String? = null
+)
+
+class GoogleCalendarFirebaseRepository {
+
+    private val db = FirebaseFirestore.getInstance()
+
+    private fun doc(uid: String) =
+        db.collection("users")
+            .document(uid)
+            .collection("integrations")
+            .document("googleCalendar")
+
+    suspend fun saveConnection(uid: String, email: String?) {
+        val data = mapOf(
+            "connected" to true,
+            "googleEmail" to email,
+            "updatedAt" to FieldValue.serverTimestamp()
+        )
+
+        doc(uid).set(data).await()
+    }
+
+    suspend fun clearConnection(uid: String) {
+        val data = mapOf(
+            "connected" to false,
+            "googleEmail" to null,
+            "updatedAt" to FieldValue.serverTimestamp()
+        )
+
+        doc(uid).set(data).await()
+    }
+
+    suspend fun getConnection(uid: String): GoogleCalendarIntegration? {
+        val snapshot = doc(uid).get().await()
+        if (!snapshot.exists()) return null
+
+        return GoogleCalendarIntegration(
+            connected = snapshot.getBoolean("connected") == true,
+            googleEmail = snapshot.getString("googleEmail")
+        )
+    }
+}

--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -23,36 +23,34 @@ import com.example.phinui.ui.screens.EventsScreen
 import com.example.phinui.ui.screens.MessagesScreen
 import com.example.phinui.ui.screens.HomeScreen
 import com.example.phinui.ui.screens.ProfileScreen
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import com.example.phinui.ui.screens.MapScreen
 import com.example.phinui.notifications.ReminderScheduler
 import com.example.phinui.viewmodel.CalendarViewModel
 import com.example.phinui.viewmodel.CalendarViewModelFactory
-import kotlinx.coroutines.withContext
 import com.example.phinui.viewmodel.AddEventResult
 import com.example.phinui.ui.screens.ScheduleScreen
 import com.example.phinui.data.calendar.CalendarSource
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.setValue
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
-import com.example.phinui.components.messages.UserListRepository
 import com.example.phinui.data.authorization.GoogleAuthManager
 import com.example.phinui.notifications.NotificationHelper.createNotificationChannels
 import com.example.phinui.screens.UserListScreen
-
-//firebase
 import com.example.phinui.ui.screens.LoginScreen
 import com.example.phinui.ui.screens.RegisterScreen
 import com.example.phinui.viewmodel.EventsRepository
 import com.example.phinui.viewmodel.EventsViewModel
 import com.example.phinui.viewmodel.EventsViewModelFactory
 import com.google.firebase.auth.FirebaseAuth
-
 import com.example.phinui.ui.screens.FriendsScreen
 import com.example.phinui.ui.screens.PeopleScreen
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CredentialManager
 
 @Composable
 fun PhinNavHost(
@@ -66,8 +64,21 @@ fun PhinNavHost(
     val allEvents = remember { mutableStateListOf<CalendarEvent>() }
     val coroutineScope = rememberCoroutineScope()
     val auth = remember { FirebaseAuth.getInstance() }
-    val startDestination = if (auth.currentUser != null) Routes.HOME else Routes.LOGIN
-    val currentUserId = auth.currentUser?.uid
+    var currentUserId by remember { mutableStateOf(auth.currentUser?.uid) }
+
+    DisposableEffect(auth) {
+        val listener = FirebaseAuth.AuthStateListener { firebaseAuth ->
+            currentUserId = firebaseAuth.currentUser?.uid
+        }
+
+        auth.addAuthStateListener(listener)
+
+        onDispose {
+            auth.removeAuthStateListener(listener)
+        }
+    }
+
+    val startDestination = if (currentUserId != null) Routes.HOME else Routes.LOGIN
 
     createNotificationChannels(context)
 
@@ -118,6 +129,8 @@ fun PhinNavHost(
     LaunchedEffect(currentUserId) {
         savedEvents.clear()
         allEvents.clear()
+        calendarViewModel.clearInMemoryState()
+        calendarViewModel.restoreConnectionFromFirebase()
         calendarViewModel.refreshEvents()
     }
 
@@ -367,18 +380,30 @@ fun PhinNavHost(
                 },
                 onConnectClick = {
                     calendarViewModel.setError(null)
-                    GoogleAuthManager.startAuthorization(
-                        activity = activity,
-                        launcher = authorizationLauncher,
-                        onAccessToken = { token ->
-                            calendarViewModel.onAuthorizationSuccess(token)
-                        },
-                        onError = { exception ->
-                            calendarViewModel.onGoogleSessionRestoreFailed(
-                                exception.message ?: "Authorization error."
+
+                    val credentialManager = CredentialManager.create(activity)
+
+                    coroutineScope.launch {
+                        try {
+                            credentialManager.clearCredentialState(
+                                ClearCredentialStateRequest()
                             )
+                        } catch (_: Exception) {
                         }
-                    )
+
+                        GoogleAuthManager.startAuthorization(
+                            activity = activity,
+                            launcher = authorizationLauncher,
+                            onAccessToken = { token ->
+                                calendarViewModel.onAuthorizationSuccess(token)
+                            },
+                            onError = { exception ->
+                                calendarViewModel.onGoogleSessionRestoreFailed(
+                                    exception.message ?: "Authorization error."
+                                )
+                            }
+                        )
+                    }
                 },
                 selectedEvent = selectedEvent,
                 showRemoveDialog = showRemoveDialog,

--- a/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModel.kt
@@ -22,6 +22,8 @@ import com.example.phinui.data.calendar.CalendarSource
 import com.example.phinui.data.authorization.GoogleCalendarSessionStorage
 import com.example.phinui.data.calendar.GoogleCalendarUnauthorizedException
 import com.example.phinui.data.calendar.FirebaseCalendarRepository
+import com.google.firebase.auth.FirebaseAuth
+import com.example.phinui.data.calendar.GoogleCalendarFirebaseRepository
 
 sealed class AddEventResult {
     data class AddedToGoogle(val event: CalendarEvent) : AddEventResult()
@@ -30,7 +32,8 @@ sealed class AddEventResult {
 class CalendarViewModel(
     private val savedStateHandle: SavedStateHandle,
     private val reminderScheduler: ReminderScheduler,
-    private val sessionStorage: GoogleCalendarSessionStorage
+    private val sessionStorage: GoogleCalendarSessionStorage,
+    private val firebaseRepository: GoogleCalendarFirebaseRepository
 ) : ViewModel() {
 
     //  Authorization + calendar data state
@@ -39,14 +42,13 @@ class CalendarViewModel(
         private set
 
     val isGoogleCalendarConnected: Boolean
-        get() = sessionStorage.isConnected()
-
+        get() = googleAccessToken != null || userEmail != null
     var isRestoringGoogleSession by mutableStateOf(false)
         private set
 
     var userEmail by mutableStateOf(
         savedStateHandle.get<String>("userEmail")
-            ?: sessionStorage.getUserEmail()
+            ?: currentFirebaseUid()?.let { sessionStorage.getUserEmail(it) }
     )
         private set
 
@@ -87,6 +89,11 @@ class CalendarViewModel(
 
     private val firebaseCalendarRepository = FirebaseCalendarRepository()
 
+
+    private fun currentFirebaseUid(): String? {
+        return FirebaseAuth.getInstance().currentUser?.uid
+    }
+
     // Load current events for the week the authorization is successful
     fun onAuthorizationSuccess(token: String) {
         googleAccessToken = token
@@ -97,14 +104,17 @@ class CalendarViewModel(
             userEmail = email
             savedStateHandle["userEmail"] = email
 
-            sessionStorage.saveSession(userEmail = email)
+            currentFirebaseUid()?.let { uid ->
+                sessionStorage.saveSession(firebaseUid = uid, userEmail = email)
+                firebaseRepository.saveConnection(uid, email)
+            }
 
             loadEventsForCurrentWeek()
         }
     }
 
     fun beginGoogleSessionRestore() {
-        if (!sessionStorage.isConnected()) return
+        if (userEmail == null) return
         if (googleAccessToken != null) return
         if (isRestoringGoogleSession) return
 
@@ -155,8 +165,7 @@ class CalendarViewModel(
         errorMessage = message
     }
 
-    // Sign out of Google Calendar for this session
-    fun signOut() {
+    fun clearInMemoryState() {
         googleAccessToken = null
         userEmail = null
         errorMessage = null
@@ -164,10 +173,37 @@ class CalendarViewModel(
         isRestoringGoogleSession = false
         eventsGroupedByDate = emptyMap()
 
-        // Clear persisted state used by this ViewModel
         savedStateHandle["userEmail"] = null
+    }
 
-        sessionStorage.clearSession()
+    // Sign out of Google Calendar for this session
+    fun signOut() {
+        val uid = currentFirebaseUid()
+
+        clearInMemoryState()
+
+        if (uid != null) {
+            sessionStorage.clearSession(uid)
+            viewModelScope.launch {
+                firebaseRepository.clearConnection(uid)
+            }
+        }
+    }
+
+    fun restoreConnectionFromFirebase() {
+        val uid = currentFirebaseUid() ?: return
+
+        viewModelScope.launch {
+            try {
+                val connection = firebaseRepository.getConnection(uid)
+
+                if (connection?.connected == true) {
+                    userEmail = connection.googleEmail
+                    savedStateHandle["userEmail"] = connection.googleEmail
+                }
+            } catch (_: Exception) {
+            }
+        }
     }
 
     fun goToCurrentWeek() {

--- a/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModelFactory.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/CalendarViewModelFactory.kt
@@ -8,8 +8,8 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
 import android.content.Context
 import com.example.phinui.data.authorization.GoogleCalendarSessionStorage
+import com.example.phinui.data.calendar.GoogleCalendarFirebaseRepository
 
-// in order to allow ReminderScheduler parameter
 class CalendarViewModelFactory(
     private val context: Context,
     private val reminderScheduler: ReminderScheduler,
@@ -18,16 +18,17 @@ class CalendarViewModelFactory(
     override fun <T : ViewModel> create(
         modelClass: Class<T>,
         extras: CreationExtras
-    ) : T {
+    ): T {
         if (modelClass.isAssignableFrom(CalendarViewModel::class.java)) {
-            // CreationExtras API to get SavedStateHandle
             val savedStateHandle: SavedStateHandle = extras.createSavedStateHandle()
             val sessionStorage = GoogleCalendarSessionStorage(context.applicationContext)
+            val firebaseRepository = GoogleCalendarFirebaseRepository()
 
             return CalendarViewModel(
                 savedStateHandle = savedStateHandle,
                 reminderScheduler = reminderScheduler,
-                sessionStorage = sessionStorage
+                sessionStorage = sessionStorage,
+                firebaseRepository = firebaseRepository
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")


### PR DESCRIPTION
- Google calendar sign in state should be saved for each users account not device
- Linked google calendar sign in state to firebase UID

How to test:
- sign into a Phin account
- sign into google calendar
- log out of that Phin account
- sign into a different Phin account
- open calendar 

Intended behavior: Google calendar sign in from previous account should not be saved on different account

- if you sign back into first Phin account your google calendar should be signed in (since thats how you left it)
- if you left it signed out it will be signed out. 
