### PR TITLE
fcmToken slight fix

### DIFF
--- a/app/src/main/java/com/example/phinui/components/SideMenu.kt
+++ b/app/src/main/java/com/example/phinui/components/SideMenu.kt
@@ -44,6 +44,8 @@ import com.example.phinui.ui.navigation.Routes
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import androidx.compose.material.icons.filled.MenuBook
+import com.example.phinui.notifications.FCMTokenManager.clearToken
+import com.example.phinui.notifications.FCMTokenManager.deleteDeviceToken
 
 data class MenuItem (
     val label: String,
@@ -144,6 +146,8 @@ fun SideMenu(
             modifier = Modifier
                 .clickable(
                     onClick = {
+                        clearToken()
+                        deleteDeviceToken()
                         auth.signOut()
                         navController.navigate(Routes.LOGIN) {
                             popUpTo(Routes.HOME) { inclusive = true }

--- a/app/src/main/java/com/example/phinui/notifications/FCMTokenManager.kt
+++ b/app/src/main/java/com/example/phinui/notifications/FCMTokenManager.kt
@@ -1,6 +1,8 @@
 package com.example.phinui.notifications
 
+import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.messaging.FirebaseMessaging
@@ -18,5 +20,26 @@ object FCMTokenManager {
                 .document(userId)
                 .set(data, SetOptions.merge())
         }
+    }
+
+    fun clearToken() {
+        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return
+
+        FirebaseFirestore.getInstance()
+            .collection("users")
+            .document(userId)
+            .update("fcmToken", FieldValue.delete())
+            .addOnSuccessListener {
+                Log.d("FCM_DEBUG", "Token removed successfully")
+            }
+            .addOnFailureListener { e ->
+                Log.d("FCM_DEBUG", "Failed to remove token: ${e.message}")
+            }
+
+
+    }
+
+    fun deleteDeviceToken() {
+        FirebaseMessaging.getInstance().deleteToken()
     }
 }

--- a/app/src/main/java/com/example/phinui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/ProfileScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import coil.compose.AsyncImage
+import com.example.phinui.notifications.FCMTokenManager.clearToken
+import com.example.phinui.notifications.FCMTokenManager.deleteDeviceToken
 import com.example.phinui.ui.navigation.Routes
 import com.example.phinui.ui.theme.Background
 import com.example.phinui.ui.theme.NavText
@@ -566,6 +568,8 @@ fun ProfileScreen(navController: NavHostController) {
         } else {
             Button(
                 onClick = {
+                    clearToken()
+                    deleteDeviceToken()
                     auth.signOut()
                     navController.navigate(Routes.LOGIN) {
                         popUpTo(Routes.HOME) { inclusive = true }


### PR DESCRIPTION
Now, when the user logs out, the fcmToken should get deleted from Firestore. This should hopefully fix the issue with users receiving notifications from other accounts that have used the same phone/emulator. However, this does require good connectivity for the emulators or Firestore won't update properly. 

To test:
- log into one account and view the fcmToken on Firestore
- log out of account and view the fcmToken deletion. If this does not happen automatically, it's usually because the emulator has bad connection. 
- log in again and view the fcmToken written to Firestore again. 