### PR TITLE
email under users in Requests tab

### DIFF
--- a/app/src/main/java/com/example/phinui/screens/FriendScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/FriendScreen.kt
@@ -366,7 +366,7 @@ fun FriendsScreen(
                                     )
 
                                     Text(
-                                        text = requestEmails[req.fromUid] ?: "",
+                                        text = email,
                                         color = TextMuted,
                                         fontSize = 12.sp,
                                         maxLines = 1


### PR DESCRIPTION
- fixed issue with email not showing under the users name in the Requests tab