### PR TITLE
update to message notifs

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -6,6 +6,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FieldValue
 
 class ChatRepository {
 
@@ -51,6 +52,8 @@ class ChatRepository {
                 )
             )
         }
+
+        setActiveChat(senderUserID, messageProperties.chatID)
     }
 
     fun sendStudySessionInvitation(
@@ -79,6 +82,9 @@ class ChatRepository {
         )
 
         messageProperties.messageReference.add(studySessionInvitation)
+
+        setActiveChat(senderUserID, messageProperties.chatID)
+
     }
 
     fun respondStudySessionInvitation(
@@ -92,6 +98,9 @@ class ChatRepository {
             .collection("messages")
             .document(messageID)
             .update("participants.$senderUserID", invitationResponse)
+
+        setActiveChat(senderUserID, chatID)
+
     }
 
     fun deleteMessage(chatID: String, messageID: String) {
@@ -205,7 +214,7 @@ class ChatRepository {
         userRef.set(
             mapOf(
                 "activeChatID" to chatID,
-                "lastActive" to com.google.firebase.Timestamp.now()
+                "lastActive" to FieldValue.serverTimestamp()
             ),
             SetOptions.merge()
         )

--- a/functions/newMessageNotif.js
+++ b/functions/newMessageNotif.js
@@ -61,7 +61,7 @@ exports.sendNewMessageNotification = onDocumentUpdated(
           lastActive && typeof lastActive.toMillis === "function" ?
           lastActive.toMillis() : 0;
         const isInChat = activeChatID === chatId;
-        const isActive = (now - lastActiveTime) < 60000;
+        const isActive = (now - lastActiveTime) < 120000;
 
         // only send if user is not on the chat screen
         if (isInChat && isActive) {


### PR DESCRIPTION
Changed a few things for new message notifications to hopefully fix notifs still appearing when on the chat screen already

- changed isActive check to two minutes instead of one
- added calls to update lastActive timestamp whenever the user sends a new message or sends/accepts a study session invite
- will still time out and consider user not active/send the notif if you don't interact in those ways after two minutes; if this is still an issue, I can update the isActive check to be longer or look into a better lastActive method

To test, just send messages between users while the chat screen is open to make sure the notifs aren't coming through. Can also check firestore to make sure the lastActive and activeChatID writes are working properly