### PR TITLE
full chat delete fixes

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -38,8 +38,8 @@ class ChatRepository {
         val chatData = hashMapOf(
             "lastMessage" to messageText,
             "lastTimestamp" to messageProperties.currentTime,
-            "messageRequestApproved" to true,
-            "participants" to listOf(senderUserID, receiverUserID)
+            "participants" to listOf(senderUserID, receiverUserID),
+            "requestState" to "approved"
         )
 
         // create message
@@ -129,8 +129,9 @@ class ChatRepository {
                 "lastMessage" to "",
                 "lastTimestamp" to messageProperties.currentTime,
                 "participants" to listOf(senderUserID, receiverUserID),
-                "messageRequestApproved" to false,
-                "senderID" to senderUserID
+                "senderID" to senderUserID,
+                "isFriendChat" to false,
+                "requestState" to "pending"
             )
         ).addOnFailureListener {
             messageProperties.chatReference.set(
@@ -138,8 +139,9 @@ class ChatRepository {
                     "lastMessage" to "",
                     "lastTimestamp" to messageProperties.currentTime,
                     "participants" to listOf(senderUserID, receiverUserID),
-                    "messageRequestApproved" to false,
-                    "senderID" to senderUserID
+                    "senderID" to senderUserID,
+                    "isFriendChat" to false,
+                    "requestState" to "pending"
                 )
             )
         }
@@ -153,7 +155,7 @@ class ChatRepository {
         chatsCollection.document(chatID)
             .update(
                 mapOf(
-                    "messageRequestApproved" to true,
+                    "requestState" to "approved",
                     "deletedBy" to FieldValue.arrayRemove(senderUserID, receiverUserID)
                 )
             )
@@ -161,7 +163,7 @@ class ChatRepository {
 
     fun denyMessageRequest(chatID: String) {
         chatsCollection.document(chatID)
-            .delete()
+            .update(mapOf("requestState" to "none"))
     }
 
     fun checkForNewMessage(senderUserID: String, receiverUserID: String, newMessage: (List<Map<String, Any>>) -> Unit) {
@@ -188,7 +190,7 @@ class ChatRepository {
     ) {
         chatsCollection
             .whereArrayContains("participants", userID)
-            .whereEqualTo("messageRequestApproved", false)
+            .whereEqualTo("requestState", "pending")
             .addSnapshotListener { snapshot, error ->
                 if (error != null || snapshot == null) return@addSnapshotListener
                 val messageRequest = snapshot.documents.mapNotNull { doc ->
@@ -209,7 +211,7 @@ class ChatRepository {
     ) {
         chatsCollection
             .whereArrayContains("participants", userID)
-            .whereEqualTo("messageRequestApproved", true)
+            .whereEqualTo("requestState", "approved")
             .addSnapshotListener { snapshot, error ->
                 if (error != null || snapshot == null) return@addSnapshotListener
                 val chats = snapshot.documents.mapNotNull { doc ->
@@ -240,12 +242,23 @@ class ChatRepository {
     }
 
     fun deleteChat(userID: String, chatID: String) {
-        chatsCollection
-            .document(chatID)
-            .update(
-                "deletedBy",
-                FieldValue.arrayUnion(userID)
-            )
+        val chatRef = chatsCollection.document(chatID)
+
+        chatRef.update("deletedBy", FieldValue.arrayUnion(userID))
+            .addOnSuccessListener {
+                chatRef.get().addOnSuccessListener { snapshot ->
+
+                    val deletedBy = snapshot.get("deletedBy") as? List<String> ?: emptyList()
+                    val participants = snapshot.get("participants") as? List<String> ?: emptyList()
+                    val isFriendChat = snapshot.getBoolean("isFriendChat") ?: false
+
+                    val bothDeleted = participants.all { deletedBy.contains(it) }
+
+                    if (bothDeleted && !isFriendChat) {
+                        chatRef.update("requestState", "none")
+                    }
+                }
+            }
     }
 
     data class MessageInfo(

--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -145,9 +145,18 @@ class ChatRepository {
         }
     }
 
-    fun approveMessageRequest(chatID: String) {
+    fun approveMessageRequest(
+        chatID: String,
+        senderUserID: String,
+        receiverUserID: String
+    ) {
         chatsCollection.document(chatID)
-            .update("messageRequestApproved", true)
+            .update(
+                mapOf(
+                    "messageRequestApproved" to true,
+                    "deletedBy" to FieldValue.arrayRemove(senderUserID, receiverUserID)
+                )
+            )
     }
 
     fun denyMessageRequest(chatID: String) {

--- a/app/src/main/java/com/example/phinui/data/friends/FriendRepository.kt
+++ b/app/src/main/java/com/example/phinui/data/friends/FriendRepository.kt
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.SetOptions
 
 data class FriendRequest(
     val id: String = "",
@@ -167,12 +168,20 @@ class FriendRepository(
             val myUserRef = db.collection("users").document(myUid)
             val otherUserRef = db.collection("users").document(fromUid)
             val requestRef = db.collection("friend_requests").document(requestId)
+            val chatID = if (myUid < fromUid) "${myUid}_$fromUid" else "${fromUid}_$myUid"
+            val chatRef = db.collection("chats").document(chatID)
 
             db.runBatch { batch ->
                 batch.update(myUserRef, "friends", FieldValue.arrayUnion(fromUid))
                 batch.update(otherUserRef, "friends", FieldValue.arrayUnion(myUid))
 
                 batch.update(requestRef, "status", "accepted")
+
+                batch.set(
+                    chatRef,
+                    mapOf("isFriendChat" to true),
+                    SetOptions.merge()
+                )
             }
                 .addOnSuccessListener { onSuccess() }
                 .addOnFailureListener(onError)
@@ -200,6 +209,9 @@ class FriendRepository(
             val myUserRef = db.collection("users").document(myUid)
             val otherUserRef = db.collection("users").document(blockedUid)
 
+            val chatID = if (myUid < blockedUid) "${myUid}_$blockedUid" else "${blockedUid}_$myUid"
+            val chatRef = db.collection("chats").document(chatID)
+
             db.collection("friend_requests")
                 .whereEqualTo("fromUid", blockedUid)
                 .whereEqualTo("toUid", myUid)
@@ -224,6 +236,12 @@ class FriendRepository(
                                     FieldValue.arrayRemove(blockedUid)
                                 )
                                 batch.update(otherUserRef, "friends", FieldValue.arrayRemove(myUid))
+
+                                batch.set(
+                                    chatRef,
+                                    mapOf("isFriendChat" to false),
+                                    SetOptions.merge()
+                                )
 
                                 incomingSnapshot.documents.forEach { doc ->
                                     batch.delete(doc.reference)
@@ -329,6 +347,9 @@ class FriendRepository(
             val myUserRef = db.collection("users").document(myUid)
             val otherUserRef = db.collection("users").document(friendUid)
 
+            val chatID = if (myUid < friendUid) "${myUid}_$friendUid" else "${friendUid}_$myUid"
+            val chatRef = db.collection("chats").document(chatID)
+
             db.collection("friend_requests")
                 .whereEqualTo("fromUid", friendUid)
                 .whereEqualTo("toUid", myUid)
@@ -348,6 +369,12 @@ class FriendRepository(
                                     FieldValue.arrayRemove(friendUid)
                                 )
                                 batch.update(otherUserRef, "friends", FieldValue.arrayRemove(myUid))
+
+                                batch.set(
+                                    chatRef,
+                                    mapOf("isFriendChat" to false),
+                                    SetOptions.merge()
+                                )
 
                                 incomingSnapshot.documents.forEach { doc ->
                                     batch.delete(doc.reference)

--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -273,7 +273,7 @@ fun PhinNavHost(
         }
 
         composable(Routes.PEOPLE) {
-            PeopleScreen()
+            PeopleScreen(navController = navController)
         }
 
         composable(

--- a/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/PeopleScreen.kt
@@ -67,11 +67,15 @@ import com.example.phinui.components.people.ActiveChatDialog
 import androidx.compose.material3.*
 import com.example.phinui.components.people.PendingFriendRequestDialog
 import androidx.compose.foundation.clickable
+import androidx.navigation.NavHostController
 import com.example.phinui.ui.components.UserProfilePreviewDialog
 import com.example.phinui.data.model.PreviewUser
+import com.example.phinui.ui.navigation.Routes
 
 @Composable
-fun PeopleScreen() {
+fun PeopleScreen(
+    navController: NavHostController
+) {
     val repo = remember { FriendRepository() }
     val db = remember { FirebaseFirestore.getInstance() }
     val auth = remember { FirebaseAuth.getInstance() }
@@ -96,6 +100,8 @@ fun PeopleScreen() {
     var userToAdd by remember { mutableStateOf<Pair<String, String>?>(null) }
     var userToBlock by remember { mutableStateOf<Pair<String, String>?>(null) }
     var userToUnblock by remember { mutableStateOf<Pair<String, String>?>(null) }
+
+    val chats = chatRepositoryViewModel.approvedChats.value
 
     LaunchedEffect(Unit) {
         val uid = auth.currentUser?.uid ?: return@LaunchedEffect
@@ -250,6 +256,19 @@ fun PeopleScreen() {
                         val email = user["email"] as? String ?: ""
                         val photoUrl = user["photoUrl"] as? String
 
+                        val currentUserId = chatRepositoryViewModel.currentUserID
+
+                        val chatForUser = chats.firstOrNull { chat ->
+                            val participants = chat["participants"] as? List<*> ?: return@firstOrNull false
+                            val ids = participants.mapNotNull { it as? String }
+
+                            currentUserId != null && currentUserId in ids && uid in ids
+                        }
+
+                        val requestState = chatForUser?.get("requestState") as? String
+                        val showSendMessage = requestState == "approved"
+                        val label = if (showSendMessage) "Send Message" else "Send Message Request"
+
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -344,21 +363,26 @@ fun PeopleScreen() {
                                             Row(verticalAlignment = Alignment.CenterVertically) {
                                                 Icon(
                                                     imageVector = Icons.Default.Email,
-                                                    contentDescription = "Send Message Request",
+                                                    contentDescription = label,
                                                     tint = NavText
                                                 )
                                                 Spacer(modifier = Modifier.width(8.dp))
-                                                Text("Send Message Request", color = NavText)
+                                                Text(label, color = NavText)
                                             }
                                         },
                                         onClick = {
                                             val senderID = chatRepositoryViewModel.currentUserID
                                                 ?: return@DropdownMenuItem
-                                            chatRepositoryViewModel.sendMessageRequest(
-                                                senderID,
-                                                uid,
-                                                name
-                                            )
+
+                                            if (showSendMessage) {
+                                                navController.navigate(Routes.MESSAGES + "/$uid")
+                                            } else {
+                                                chatRepositoryViewModel.sendMessageRequest(
+                                                    senderID,
+                                                    uid,
+                                                    name
+                                                )
+                                            }
                                             showMenu = false
                                         }
                                     )

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -434,7 +434,9 @@ fun UserListScreen (
                                         IconButton(
                                             onClick = {
                                                 chatRepositoryViewModel.approveRequest(
-                                                    chatID
+                                                    chatID,
+                                                    currentUserID,
+                                                    otherUserID
                                                 )
                                             }
                                         ) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -205,8 +205,12 @@ class ChatRepositoryViewModel (
         chatRepository.respondStudySessionInvitation(chatID, messageID, senderUserID, invitationResponse)
     }
 
-    fun approveRequest(chatID: String) {
-        chatRepository.approveMessageRequest(chatID)
+    fun approveRequest(
+        chatID: String,
+        senderUserID: String,
+        receiverUserID: String
+    ) {
+        chatRepository.approveMessageRequest(chatID, senderUserID, receiverUserID)
     }
 
     fun denyRequest(chatID: String) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -144,9 +144,9 @@ class ChatRepositoryViewModel (
                 senderUserID in userIDs && receiverUserID in userIDs
             }
 
-            val isMessageRequestApproved =
-                checkChat?.get("messageRequestApproved") as? Boolean ?: false
-            if (isMessageRequestApproved) {
+            val requestState = checkChat?.get("requestState") as? String
+
+            if (requestState == "approved" || requestState == "pending") {
                 return@runTransaction "CHAT_EXISTS"
             }
 

--- a/functions/acceptMessageRequestNotif.js
+++ b/functions/acceptMessageRequestNotif.js
@@ -21,7 +21,9 @@ exports.sendAcceptMessageRequestNotification = onDocumentUpdated(
       }
 
       // only send if messageRequestApproved changes TO accepted
-      if (before.messageRequestApproved || !after.messageRequestApproved) {
+      if (before.requestState === "approved" ||
+        after.requestState !== "approved"
+      ) {
         return null;
       }
 

--- a/functions/messageRequestNotif.js
+++ b/functions/messageRequestNotif.js
@@ -1,20 +1,27 @@
-const {onDocumentCreated} = require("firebase-functions/v2/firestore");
+const {onDocumentWritten} = require("firebase-functions/v2/firestore");
 const admin = require("firebase-admin");
 
 console.log("MESSAGE REQUEST FUNCTION STARTED");
 
-exports.sendMessageRequestNotification = onDocumentCreated(
+exports.sendMessageRequestNotification = onDocumentWritten(
     {
       region: "us-central1",
       document: "chats/{requestId}",
     },
     async (event) => {
-      const snapshot = event.data;
-      if (!snapshot) return;
+      const before = event.data.before ? event.data.before.data() : null;
+      const after = event.data.after ? event.data.after.data() : null;
 
-      const data = snapshot.data();
-      const receiverId = data.participants[1];
-      const senderId = data.participants[0];
+      if (!after) return null;
+
+      // only fire when request becomes pending
+      if (after.requestState !== "pending") return null;
+
+      // prevent duplicate firing
+      if (before && before.requestState === "pending") return null;
+
+      const receiverId = after.participants[1];
+      const senderId = after.participants[0];
 
       if (!receiverId) {
         console.log("Missing toUid");


### PR DESCRIPTION
Fixed some of the issues that were occurring due to the scenario:

 if both users are participants of a chat in the General tab and they both delete the chat
 - before: sending a message request -> accepting a message request did not make the chat show up in the General tab
 - after: now it should work

Fixing that issue caused other bugs to pop up, which have been alleviated with the other changes:
- switching UI triggers from messageRequestApproved flag to requestStatus flag (which can be "accepted"/"pending"/"none")
- adding an isFriendChat flag to the chat documents
- if the requestStatus flag == "accepted", the drop down menu in the Discover tab of the People Screen will show a "Send Message" button instead of a "Send Message Request" screen
- if a user denies a friend request, the requestStatus flag will be set to "none" instead of having the document get deleted
- notification cloud functions check for change in requestStatus instead of messageRequestApproved/document creation now

For testing, it would be beneficial to try different combinations of friending/deleting/sending message requests just to make sure this update isn't interfering with other features. But the most prevalent one would be:
- have a chat in the General tab
- delete the chat for both users
- have one user send a message request
- have other user accept friend request
- check to see if the chat shows up in the General tab again
- check to see if notifs are firing correctly