### PR TITLE
Mute chat

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -13,7 +13,6 @@ class ChatRepository {
 
     private val database = FirebaseFirestore.getInstance()
     private val chatsCollection = database.collection("chats")
-    private val usersCollection = database.collection("users")
 
     //Link users for 1 on 1 messaging
     fun getChatID(firstUserID: String, secondUserID: String): String {

--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -277,26 +277,17 @@ class ChatRepository {
                 val chats = snapshot.documents.mapNotNull { doc ->
                     val data = doc.data ?: return@mapNotNull null
                     val deletedBy = data["deletedBy"] as? List<String> ?: emptyList()
+                    val mutedBy = data["mutedBy"] as? List<String> ?: emptyList()
+                    val isMuted = mutedBy.contains(userID)
 
                     if (deletedBy.contains(userID)) return@mapNotNull null
 
-                    data + mapOf("chatID" to doc.id)
+                    data + mapOf(
+                        "chatID" to doc.id,
+                        "isMuted" to isMuted
+                        )
                 }
                 onResult(chats)
-            }
-    }
-
-    fun listenMutedChats(
-        userID: String,
-        onResult: (Set<String>) -> Unit
-    ) {
-        usersCollection
-            .document(userID)
-            .addSnapshotListener { snapshot, error ->
-                if (error != null || snapshot == null) return@addSnapshotListener
-
-                val mutedChats = snapshot.get("mutedChats") as? List<String> ?: emptyList()
-                onResult(mutedChats.toSet())
             }
     }
 
@@ -335,30 +326,16 @@ class ChatRepository {
             }
     }
 
-    fun muteChat(
-        userID: String,
-        chatID: String,
-        onSuccess: () -> Unit = {},
-        onError: (Exception) -> Unit = {}
-        ) {
-        val userRef = usersCollection.document(userID)
+    fun muteChat(userID: String, chatID: String) {
+        val chatRef = chatsCollection.document(chatID)
 
-        userRef.update("mutedChats", FieldValue.arrayUnion(chatID))
-            .addOnSuccessListener { onSuccess() }
-            .addOnFailureListener { onError(it) }
+        chatRef.update("mutedBy", FieldValue.arrayUnion(userID))
     }
 
-    fun unmuteChat(
-        userID: String,
-        chatID: String,
-        onSuccess: () -> Unit = {},
-        onError: (Exception) -> Unit = {}
-    ) {
-        val userRef = usersCollection.document(userID)
+    fun unmuteChat(userID: String, chatID: String) {
+        val chatRef = chatsCollection.document(chatID)
 
-        userRef.update("mutedChats", FieldValue.arrayRemove(chatID))
-            .addOnSuccessListener { onSuccess() }
-            .addOnFailureListener { onError(it) }
+        chatRef.update("mutedBy", FieldValue.arrayRemove(userID))
     }
 
     data class MessageInfo(

--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -13,6 +13,7 @@ class ChatRepository {
 
     private val database = FirebaseFirestore.getInstance()
     private val chatsCollection = database.collection("chats")
+    private val usersCollection = database.collection("users")
 
     //Link users for 1 on 1 messaging
     fun getChatID(firstUserID: String, secondUserID: String): String {
@@ -228,6 +229,20 @@ class ChatRepository {
             }
     }
 
+    fun listenMutedChats(
+        userID: String,
+        onResult: (Set<String>) -> Unit
+    ) {
+        usersCollection
+            .document(userID)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null || snapshot == null) return@addSnapshotListener
+
+                val mutedChats = snapshot.get("mutedChats") as? List<String> ?: emptyList()
+                onResult(mutedChats.toSet())
+            }
+    }
+
     fun setActiveChat(userID: String, chatID: String?) {
         val userRef = database
             .collection("users")
@@ -261,6 +276,32 @@ class ChatRepository {
                     }
                 }
             }
+    }
+
+    fun muteChat(
+        userID: String,
+        chatID: String,
+        onSuccess: () -> Unit = {},
+        onError: (Exception) -> Unit = {}
+        ) {
+        val userRef = usersCollection.document(userID)
+
+        userRef.update("mutedChats", FieldValue.arrayUnion(chatID))
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { onError(it) }
+    }
+
+    fun unmuteChat(
+        userID: String,
+        chatID: String,
+        onSuccess: () -> Unit = {},
+        onError: (Exception) -> Unit = {}
+    ) {
+        val userRef = usersCollection.document(userID)
+
+        userRef.update("mutedChats", FieldValue.arrayRemove(chatID))
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { onError(it) }
     }
 
     data class MessageInfo(

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -76,7 +76,6 @@ fun UserListScreen (
     val usersDataBase = chatRepositoryViewModel.firebaseFirestoreAuthenticated
     var message by remember { mutableStateOf<String?>(null) }
 
-    //var showDeleteDialog = remember { mutableStateOf(false) }
     var selectedChatID by remember { mutableStateOf<String?>(null) }
     var showActionSheet by remember { mutableStateOf(false) }
     val mutedChats by chatRepositoryViewModel.mutedChats.collectAsState()

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -98,10 +98,6 @@ fun UserListScreen (
     }
 
     LaunchedEffect(currentUserID) {
-        chatRepositoryViewModel.loadMutedChats(currentUserID)
-    }
-
-    LaunchedEffect(currentUserID) {
         chatRepositoryViewModel.userListRepository.loadCurrentUserBlockedListListener(currentUserID)
         chatRepositoryViewModel.userListRepository.loadBlockedByOtherUsersListListener(currentUserID)
     }
@@ -110,41 +106,7 @@ fun UserListScreen (
     val blockedByOtherUsersList = chatRepositoryViewModel.userListRepository.blockedByOtherUsersList.value
     val hideBlockedUsers = currentUserBlockedList + blockedByOtherUsersList
 
-    /*
-    if (showDeleteDialog.value && selectedChatID.value != null) {
-        AlertDialog(
-            onDismissRequest = {
-                showDeleteDialog.value = false
-                selectedChatID.value = null
-            },
-            title = { Text("Delete chat?") },
-            text = { Text("This chat will be deleted from your current chat list.") },
-            confirmButton = {
-                TextButton(onClick = {
-                    chatRepositoryViewModel.onDeleteChat(
-                        userID = currentUserID,
-                        chatID = selectedChatID.value!!
-                    )
-                    showDeleteDialog.value = false
-                    selectedChatID.value = null
-                }) {
-                    Text("Delete")
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        showDeleteDialog.value = false
-                        selectedChatID.value = null
-                    }
-                ) {
-                    Text("Cancel")
-                }
-            }
-        )
-    }
 
-     */
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -1,5 +1,6 @@
 package com.example.phinui.screens
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.lazy.*
@@ -26,9 +27,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.saveable.rememberSaveable
 import com.example.phinui.components.people.BlockFriendDialog
 import com.example.phinui.components.people.BlockUserDialog
@@ -42,8 +46,10 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import com.example.phinui.ui.components.UserAvatar
+import com.google.firebase.firestore.FirebaseFirestore
 
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UserListScreen (
     navController: NavController,
@@ -67,8 +73,10 @@ fun UserListScreen (
     val usersDataBase = chatRepositoryViewModel.firebaseFirestoreAuthenticated
     var message by remember { mutableStateOf<String?>(null) }
 
-    var showDeleteDialog = remember { mutableStateOf(false) }
-    var selectedChatID = remember { mutableStateOf<String?>(null) }
+    //var showDeleteDialog = remember { mutableStateOf(false) }
+    var selectedChatID by remember { mutableStateOf<String?>(null) }
+    var showActionSheet by remember { mutableStateOf(false) }
+    val mutedChats by chatRepositoryViewModel.mutedChats.collectAsState()
 
 
     LaunchedEffect(Unit) {
@@ -87,6 +95,10 @@ fun UserListScreen (
     }
 
     LaunchedEffect(currentUserID) {
+        chatRepositoryViewModel.loadMutedChats(currentUserID)
+    }
+
+    LaunchedEffect(currentUserID) {
         chatRepositoryViewModel.userListRepository.loadCurrentUserBlockedListListener(currentUserID)
         chatRepositoryViewModel.userListRepository.loadBlockedByOtherUsersListListener(currentUserID)
     }
@@ -95,6 +107,7 @@ fun UserListScreen (
     val blockedByOtherUsersList = chatRepositoryViewModel.userListRepository.blockedByOtherUsersList.value
     val hideBlockedUsers = currentUserBlockedList + blockedByOtherUsersList
 
+    /*
     if (showDeleteDialog.value && selectedChatID.value != null) {
         AlertDialog(
             onDismissRequest = {
@@ -127,6 +140,8 @@ fun UserListScreen (
             }
         )
     }
+
+     */
 
     Column(modifier = Modifier
         .fillMaxSize()
@@ -257,8 +272,8 @@ fun UserListScreen (
                                     navController.navigate(Routes.MESSAGES + "/${friendId}")
                                 },
                                 onLongPress = {
-                                    selectedChatID.value = chatID
-                                    showDeleteDialog.value = true
+                                    selectedChatID = chatID
+                                    showActionSheet = true
                                 }
                             )
                             Spacer(modifier = Modifier.height(5.dp))
@@ -379,8 +394,8 @@ fun UserListScreen (
                                     navController.navigate(Routes.MESSAGES + "/${user.uid}")
                                 },
                                 onLongPress = {
-                                    selectedChatID.value = chatID
-                                    showDeleteDialog.value = true
+                                    selectedChatID = chatID
+                                    showActionSheet = true
                                 }
                             )
                             Spacer(modifier = Modifier.height(5.dp))
@@ -544,6 +559,66 @@ fun UserListScreen (
             },
             onDismiss = { friendToBlock = null }
         )
+    }
+
+    if (showActionSheet && selectedChatID != null) {
+        val isMuted = selectedChatID != null && selectedChatID in mutedChats
+
+        ModalBottomSheet(
+            onDismissRequest = {
+                showActionSheet = false
+                selectedChatID = null
+            }
+        ) {
+            Text(
+                text = "Chat Actions",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(16.dp)
+            )
+
+            HorizontalDivider()
+
+            ListItem(
+                headlineContent = { Text("Delete Chat") },
+                leadingContent = { Icon(Icons.Default.Delete, contentDescription = null) },
+                modifier = Modifier.clickable {
+                    chatRepositoryViewModel.onDeleteChat(
+                        userID = currentUserID,
+                        chatID = selectedChatID!!
+                    )
+                    showActionSheet = false
+                    selectedChatID = null
+                }
+            )
+
+            ListItem(
+                headlineContent = {
+                    Text(if (isMuted) "Unmute Chat" else "Mute Chat")
+                },
+                leadingContent = {
+                    if (isMuted) {
+                        Icon(Icons.Default.VolumeUp, contentDescription = null)
+                    } else {
+                        Icon(Icons.Default.VolumeOff, contentDescription = null)
+                    }
+                },
+                modifier = Modifier.clickable {
+                    if (isMuted) {
+                        chatRepositoryViewModel.onUnmuteChat(
+                            chatID = selectedChatID!!
+                        )
+                    } else {
+                        chatRepositoryViewModel.onMuteChat(
+                            chatID = selectedChatID!!
+                        )
+                    }
+                    showActionSheet = false
+                    selectedChatID = null
+                }
+            )
+
+            Spacer(Modifier.height(16.dp))
+        }
     }
 
 }

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -103,8 +103,18 @@ class ChatRepositoryViewModel (
     }
 
     fun loadApprovedChats(userID: String) {
-        chatRepository.listenChats(userID) {
-            approvedChats.value = it
+        chatRepository.listenChats(userID) { chats ->
+            approvedChats.value = chats
+
+            // extract muted chat IDs
+            val mutedSet = chats.mapNotNull { chat ->
+                val mutedBy = chat["mutedBy"] as? List<String> ?: emptyList()
+                val chatID = chat["chatID"] as? String ?: return@mapNotNull null
+
+                if (mutedBy.contains(userID)) chatID else null
+            }.toSet()
+
+            _mutedChats.value = mutedSet
         }
     }
 
@@ -246,12 +256,6 @@ class ChatRepositoryViewModel (
 
     fun onDeleteChat(userID: String, chatID: String) {
         chatRepository.deleteChat(userID, chatID)
-    }
-
-    fun loadMutedChats(userId: String) {
-        chatRepository.listenMutedChats(userId) { set ->
-            _mutedChats.value = set
-        }
     }
 
     fun onMuteChat(chatID: String) {

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -12,6 +12,8 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.Timestamp
 import com.example.phinui.data.CampusLocation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class ChatRepositoryViewModel (
     private val chatRepository: ChatRepository = ChatRepository(),
@@ -29,6 +31,9 @@ class ChatRepositoryViewModel (
     var activeChatUserName = mutableStateOf<String?>(null)
 
     val confirmSendMessageRequest = mutableStateOf<String?>(null)
+
+    private val _mutedChats = MutableStateFlow<Set<String>>(emptySet())
+    val mutedChats = _mutedChats.asStateFlow()
 
     // FOR FILTERING FRIENDS FROM GENERAL
     val friendsList = mutableStateOf<List<User>>(emptyList())
@@ -241,6 +246,20 @@ class ChatRepositoryViewModel (
 
     fun onDeleteChat(userID: String, chatID: String) {
         chatRepository.deleteChat(userID, chatID)
+    }
+
+    fun loadMutedChats(userId: String) {
+        chatRepository.listenMutedChats(userId) { set ->
+            _mutedChats.value = set
+        }
+    }
+
+    fun onMuteChat(chatID: String) {
+        chatRepository.muteChat(currentUserID!!, chatID)
+    }
+
+    fun onUnmuteChat(chatID: String) {
+        chatRepository.unmuteChat(currentUserID!!, chatID)
     }
 
     fun callSendPinMessage(

--- a/functions/newMessageNotif.js
+++ b/functions/newMessageNotif.js
@@ -23,6 +23,7 @@ exports.sendNewMessageNotification = onDocumentCreated(
 
         const chatDoc = await db.collection("chats").doc(chatId).get();
         const chatData = chatDoc.data();
+        const mutedBy = chatData.mutedBy || [];
 
         if (!chatData || !chatData.participants) return null;
 
@@ -31,6 +32,11 @@ exports.sendNewMessageNotification = onDocumentCreated(
         );
 
         if (!receiverId) return null;
+
+        if (mutedBy.includes(receiverId)) {
+          console.log("Chat is muted by receiver. Skipping notification");
+          return null;
+        }
 
         const receiverDoc = await db.collection("users").doc(receiverId).get();
         const receiverData = receiverDoc.data();


### PR DESCRIPTION
Added the ability to mute a chat so that the user no longer receives push notifications for it. The user can enable it for any of the chats they have in their Friends/General tab by long pressing on a chat. The long press prompts a Modal Bottom Sheet now instead of an Alert Dialog, so as to accommodate both the Delete and Mute options. If the user mutes a chat, they can then choose to unmute a chat the same way. Deleting a chat does not change the mute status. 