### PR TITLE
Messaging - number of message requests

### DIFF
--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -105,7 +105,18 @@ fun UserListScreen (
     val blockedByOtherUsersList = chatRepositoryViewModel.userListRepository.blockedByOtherUsersList.value
     val hideBlockedUsers = currentUserBlockedList + blockedByOtherUsersList
 
+    val messageRequestsCountState = chatRepositoryViewModel.messageRequests.value
 
+    val userCountCache = remember { mutableStateOf<Map<String, User>>(emptyMap()) }
+
+    val sortedCountChats = getSortedChats(
+        approvedChatsState = messageRequestsCountState,
+        chatRepositoryViewModel = chatRepositoryViewModel,
+        userCache = userCountCache,
+        currentUserID = currentUserID
+    )
+
+    val totalCountChats = sortedCountChats.size
 
     Column(
         modifier = Modifier
@@ -124,7 +135,14 @@ fun UserListScreen (
             }
             Tab(selected = selectedTab == 2,
                 onClick = {selectedTab = 2}) {
-                Text("Requests")
+                if (totalCountChats >= 1) {
+                    Text(
+                        "Requests (${totalCountChats})"
+                    )
+                }
+                else {
+                    Text("Requests")
+                }
             }
         }
 
@@ -391,7 +409,6 @@ fun UserListScreen (
             //Requests tab
             2 -> {
                 val messageRequestState = chatRepositoryViewModel.messageRequests.value
-
                 val userCache = remember { mutableStateOf<Map<String, User>>(emptyMap()) }
 
                 val alphabetizedChats = getSortedChats(


### PR DESCRIPTION
A number is now displayed for the message request tab so that users know they have requests to review.

To test

1. Go to the message screen
2. Request tab should now show "Requests (x)" if there are requests to review
    - if there are no requests, then only the "Requests" text will be displayed.
3. Send a message request to the test account to see the number update in real-time 