### PR TITLE
Messaging - friend and general tabs number notification 

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -56,6 +56,15 @@ class ChatRepository {
             FieldValue.arrayRemove(senderUserID, receiverUserID)
         )
 
+        // add count for unread messages
+        batch.update(
+            chatRef,
+            mapOf(
+                "unreadCounts.$receiverUserID" to FieldValue.increment(1),
+                "unreadCounts.$senderUserID" to 0
+            )
+        )
+
         // commit everything atomically
         batch.commit()
 
@@ -302,7 +311,14 @@ class ChatRepository {
             ),
             SetOptions.merge()
         )
+    }
 
+    fun unreadCountChats(userID: String, chatID: String) {
+        val unreadCountRef = database
+            .collection("chats")
+            .document(chatID)
+
+        unreadCountRef.update("unreadCounts.$userID", 0)
     }
 
     fun deleteChat(userID: String, chatID: String) {

--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -179,6 +179,8 @@ fun MessagesScreen(
     }
 
     LaunchedEffect(messages) {
+        chatRepositoryViewModel.markChatsAsRead(senderUserID, chatID)
+
         if (messages.isNotEmpty()) {
             val lastMessage = messages.size - 1
             val userIsNearBottomChat = autoScrollState.layoutInfo.visibleItemsInfo.lastOrNull()

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -116,7 +116,38 @@ fun UserListScreen (
         currentUserID = currentUserID
     )
 
-    val totalCountChats = sortedCountChats.size
+    val totalMessageRequestCount = sortedCountChats.size
+
+    val friendMessagesCount = chatRepositoryViewModel.getFriendChats.value
+    val userCacheCount = remember { mutableStateOf<Map<String, User>>(emptyMap()) }
+
+    val generalMessagesStateCount = chatRepositoryViewModel.getGeneralChats.value
+
+    val sortedFriendMessagesCount = getSortedChats(
+        approvedChatsState = friendMessagesCount,
+        chatRepositoryViewModel = chatRepositoryViewModel,
+        userCache = userCacheCount,
+        currentUserID = currentUserID
+    )
+
+    val sortedGeneralMessagesStateCount = getSortedChats(
+        approvedChatsState = generalMessagesStateCount,
+        chatRepositoryViewModel = chatRepositoryViewModel,
+        userCache = userCacheCount,
+        currentUserID = currentUserID
+    )
+
+    val totalFriendsMessagesCount = sortedFriendMessagesCount.sumOf { chat ->
+        val unreadFriendsMessagesCount = chat["unreadCounts"] as? Map<String, Long> ?: emptyMap()
+
+        unreadFriendsMessagesCount[currentUserID]?.toInt() ?: 0
+    }
+
+    val totalGeneralMessagesCount = sortedGeneralMessagesStateCount.sumOf { chat ->
+        val unreadGeneralMessagesCount = chat["unreadCounts"] as? Map<String, Long> ?: emptyMap()
+
+        unreadGeneralMessagesCount[currentUserID]?.toInt() ?: 0
+    }
 
     Column(
         modifier = Modifier
@@ -127,17 +158,27 @@ fun UserListScreen (
         TabRow(selectedTabIndex = selectedTab) {
             Tab(selected = selectedTab == 0,
                 onClick = {selectedTab = 0}) {
-                Text("Friends")
+                if (totalFriendsMessagesCount > 0) {
+                    Text("Friends (${totalFriendsMessagesCount})")
+                }
+                else {
+                    Text("Friends")
+                }
             }
             Tab(selected = selectedTab == 1,
                 onClick = {selectedTab = 1}) {
-                Text("General")
+                if (totalGeneralMessagesCount > 0) {
+                    Text("General (${totalGeneralMessagesCount})")
+                }
+                else {
+                    Text("General")
+                }
             }
             Tab(selected = selectedTab == 2,
                 onClick = {selectedTab = 2}) {
-                if (totalCountChats >= 1) {
+                if (totalMessageRequestCount > 0) {
                     Text(
-                        "Requests (${totalCountChats})"
+                        "Requests (${totalMessageRequestCount})"
                     )
                 }
                 else {
@@ -280,6 +321,7 @@ fun UserListScreen (
                     userCache = userCache,
                     currentUserID = currentUserID
                 )
+                
                 Box {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -173,6 +173,12 @@ fun UserListScreen (
                             val participants = chat["participants"] as List<String>
                             val friendId = participants.first { it != currentUserID }
 
+                            val unreadCounts =
+                                chat["unreadCounts"] as? Map<String, Long> ?: emptyMap()
+
+                            val unreadCount =
+                                unreadCounts[currentUserID]?.toInt() ?: 0
+
                             if(friendId in hideBlockedUsers) return@items
 
                             val friendUser = friendList.firstOrNull { it.uid == friendId } ?: User(
@@ -191,6 +197,7 @@ fun UserListScreen (
                             }
                             UserListItem(
                                 user = friendUser,
+                                unreadCount = unreadCount,
                                 subtitle = previewText,
                                 timeText = formatTimestamp(timestamp),
                                 trailingContent = {
@@ -246,20 +253,6 @@ fun UserListScreen (
                                                     friendToBlock = friendId to friendUser.name
                                                 }
                                             )
-
-//                                            DropdownMenuItem(
-//                                                text = {
-//                                                    Row(verticalAlignment = Alignment.CenterVertically) {
-//                                                        Icon(Icons.Default.Delete, contentDescription = "Delete", tint = HeaderRed)
-//                                                        Spacer(modifier = Modifier.width(8.dp))
-//                                                        Text("Delete", color = HeaderRed)
-//                                                    }
-//                                                },
-//                                                onClick = {
-//                                                    showMenu = false
-//                                                    //chatRepositoryViewModel.denyRequest(chatID)
-//                                                }
-//                                            )
                                         }
                                     }
                                 },
@@ -297,6 +290,12 @@ fun UserListScreen (
 
                             val participants = chat["participants"] as? List<*> ?: return@items
 
+                            val unreadCounts =
+                                chat["unreadCounts"] as? Map<String, Long> ?: emptyMap()
+
+                            val unreadCount =
+                                unreadCounts[currentUserID]?.toInt() ?: 0
+
                             val otherUserID = participants
                                 .mapNotNull { it as? String }
                                 .firstOrNull{ it != currentUserID } ?:return@items
@@ -320,6 +319,7 @@ fun UserListScreen (
 
                             UserListItem(
                                 user = user,
+                                unreadCount = unreadCount,
                                 subtitle = previewText,
                                 timeText = formatTimestamp(timestamp),
                                 trailingContent = {
@@ -376,20 +376,6 @@ fun UserListScreen (
                                                     userToBlock = otherUserID to user.name
                                                 }
                                             )
-
-//                                            DropdownMenuItem(
-//                                                text = {
-//                                                    Row(verticalAlignment = Alignment.CenterVertically) {
-//                                                        Icon(Icons.Default.Delete, contentDescription = "Delete", tint = HeaderRed)
-//                                                        Spacer(modifier = Modifier.width(8.dp))
-//                                                        Text("Delete", color = HeaderRed)
-//                                                    }
-//                                                },
-//                                                onClick = {
-//                                                    showMenu = false
-//                                                    //chatRepositoryViewModel.denyRequest(chatID)
-//                                                }
-//                                            )
                                         }
                                     }
                                 },
@@ -441,6 +427,7 @@ fun UserListScreen (
 
                             UserListItem(
                                 user = user,
+                                unreadCount = 0,
                                 trailingContent = {
                                     Row(
                                         horizontalArrangement = Arrangement.spacedBy(2.dp),
@@ -626,6 +613,7 @@ fun UserListScreen (
 @Composable
 fun UserListItem(
     user: User,
+    unreadCount: Int,
     subtitle: String = "",
     timeText: String? = null,
     trailingContent: @Composable (() -> Unit)? = null,
@@ -665,7 +653,12 @@ fun UserListItem(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = user.name,
+                        text = if (unreadCount > 0) {
+                            user.name + "  ($unreadCount)"
+                        }
+                        else {
+                            user.name
+                        },
                         style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.onTertiary

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.*
-import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavController
 import com.example.phinui.ui.navigation.Routes
 import androidx.compose.material3.Text
@@ -20,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.phinui.components.messages.User
-import com.example.phinui.ui.theme.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Check
@@ -49,7 +47,6 @@ import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
-import com.google.firebase.firestore.FirebaseFirestore
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -321,7 +318,7 @@ fun UserListScreen (
                     userCache = userCache,
                     currentUserID = currentUserID
                 )
-                
+
                 Box {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -248,6 +248,11 @@ class ChatRepositoryViewModel (
 
     fun onChatOpened(userID: String, chatID: String) {
         chatRepository.setActiveChat(userID, chatID)
+        chatRepository.unreadCountChats(userID, chatID)
+    }
+
+    fun markChatsAsRead(userID: String, chatID: String) {
+        chatRepository.unreadCountChats(userID, chatID)
     }
 
     fun onChatClosed(userID: String) {


### PR DESCRIPTION
A number is now displayed for both friend and general tabs so that users know they have new messages. A number of new messages is also displayed for each user in the list of friend or general tabs. The numbers are updated in real-time and they reset to 0 when selecting a chat that has new messages.

To test

1. Go to the message screen
2. Friends or General tab should now show "Friends (x)" or "General (x)" if there are new messages from any user in that list.
    - if there are no new messages, then only the "Friends" or "General" text will be displayed.
    - The tab will show the total number of new messages, while each chat will display how many new messages have been received from that user
3. Send a message to a test account to see the number update in real-time