### PR TITLE
Group chats - display number notification and share campus pins

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -1,5 +1,6 @@
 package com.example.phinui.components.messages
 
+import androidx.compose.runtime.mutableStateOf
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
@@ -494,6 +495,20 @@ class ChatRepository {
                         FieldValue.arrayRemove(*participants.toTypedArray())
                     )
                 }
+
+                val unreadMessagesAllParticipants = mutableMapOf<String, Any>()
+
+                participants.forEach {participantID ->
+                    unreadMessagesAllParticipants["unreadCounts.$participantID"] =
+                        if (participantID == senderUserID) {
+                            0
+                        }
+                        else {
+                            FieldValue.increment(1)
+                        }
+                }
+
+                batch.update(chatRef, unreadMessagesAllParticipants)
 
                 batch.commit()
                     .addOnSuccessListener {

--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -1,5 +1,6 @@
 package com.example.phinui.components.messages
 
+import androidx.compose.animation.core.snap
 import androidx.compose.runtime.mutableStateOf
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
@@ -424,6 +425,80 @@ class ChatRepository {
         setActiveChat(senderUserID, messageProperties.chatID)
     }
 
+    fun sendPinGroupMessage(
+        senderUserID: String,
+        chatID: String,
+        location: CampusLocation
+    ) {
+        val chatRef = chatsCollection.document(chatID)
+        val messageRef = chatRef.collection("messages").document()
+        val currentTime = Timestamp.now()
+
+        chatRef.get()
+            .addOnSuccessListener { snapshot ->
+                val participants = snapshot.get("participants") as? List<String> ?: emptyList()
+
+                val pinPayload = hashMapOf(
+                    "id" to location.id,
+                    "name" to location.name,
+                    "category" to location.category,
+                    "latitude" to location.latitude,
+                    "longitude" to location.longitude,
+                    "building" to location.building,
+                    "description" to location.description,
+                    "isActive" to location.isActive,
+                    "source" to "campus"
+                )
+
+                val message = hashMapOf(
+                    "type" to "pin",
+                    "senderID" to senderUserID,
+                    "text" to "",
+                    "timestamp" to currentTime,
+                    "deleted" to false,
+                    "pin" to pinPayload
+                )
+
+                val chatData = hashMapOf(
+                    "lastMessage" to "Shared a pin: ${location.name}",
+                    "lastTimestamp" to currentTime
+                )
+
+                val batch = database.batch()
+
+                batch.set(messageRef, message)
+                batch.set(chatRef, chatData, SetOptions.merge())
+
+                if (participants.isNotEmpty()) {
+                    batch.update(
+                        chatRef,
+                        "deletedBy",
+                        FieldValue.arrayRemove(*participants.toTypedArray())
+                    )
+
+                    val unreadPinMessageAllParticipants = mutableMapOf<String, Any>()
+                    participants.forEach { participantID ->
+                        unreadPinMessageAllParticipants["unreadCounts.$participantID"] =
+                            if (participantID == senderUserID) {
+                                0
+                            } else {
+                                FieldValue.increment(1)
+                            }
+                    }
+
+                    batch.update(
+                        chatRef,
+                        unreadPinMessageAllParticipants
+                    )
+                }
+
+                batch.commit()
+                    .addOnSuccessListener{
+                        setActiveChat(senderUserID, chatID)
+                }
+            }
+    }
+
     fun createGroupChat(
         creatorUserID: String,
         participantIDs: List<String>,
@@ -587,6 +662,21 @@ class ChatRepository {
                         chatRef,
                         "deletedBy",
                         FieldValue.arrayRemove(*participants.toTypedArray())
+                    )
+
+                    val unreadStudySessionMessageAllParticipants = mutableMapOf<String, Any>()
+                    participants.forEach { participantID ->
+                        unreadStudySessionMessageAllParticipants["unreadCounts.$participantID"] =
+                            if (participantID == senderUserID) {
+                                0
+                            } else {
+                                FieldValue.increment(1)
+                            }
+                    }
+
+                    batch.update(
+                        chatRef,
+                        unreadStudySessionMessageAllParticipants
                     )
                 }
 

--- a/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/MessagesScreen.kt
@@ -765,11 +765,20 @@ fun MessagesScreen(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .clickable {
-                                        chatRepositoryViewModel.callSendPinMessage(
-                                            senderUserID = senderUserID,
-                                            receiverUserID = receiverUserID,
-                                            location = pin
-                                        )
+                                        if (isGroupChat) {
+                                            chatRepositoryViewModel.callSendPingGroupMessage(
+                                                senderUserID = senderUserID,
+                                                chatID = resolvedChatID,
+                                                location = pin
+                                            )
+                                        }
+                                        else {
+                                            chatRepositoryViewModel.callSendPinMessage(
+                                                senderUserID = senderUserID,
+                                                receiverUserID = receiverUserID,
+                                                location = pin
+                                            )
+                                        }
                                         showPinPickerDialog = false
                                     }
                                     .padding(vertical = 12.dp)

--- a/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
+++ b/app/src/main/java/com/example/phinui/screens/UserListScreen.kt
@@ -385,103 +385,118 @@ fun UserListScreen (
 
                             val participants = chat["participants"] as? List<*> ?: return@items
 
+                            val chatType = chat["type"] as? String
+                                ?: if (participants.size > 2) "group" else "direct"
+
                             val unreadCounts =
                                 chat["unreadCounts"] as? Map<String, Long> ?: emptyMap()
 
                             val unreadCount =
                                 unreadCounts[currentUserID]?.toInt() ?: 0
 
-                            val otherUserID = participants
-                                .mapNotNull { it as? String }
-                                .firstOrNull{ it != currentUserID } ?:return@items
-
-                            if(otherUserID in hideBlockedUsers) return@items
-
-                            val user = userCache.value[otherUserID] ?: User(
-                                uid = otherUserID,
-                                name = "Loading Chat...",
-                                photoUrl = null
-                            )
-
-                            val lastMessage = chat["lastMessage"] as? String ?: ""
-                            val timestamp = chat["lastTimestamp"] as? Timestamp
-
-                            val previewText = if (lastMessage.isBlank()) {
-                                "Start conversation"
-                            } else {
-                                lastMessage
+                            if (chatType != "direct") {
+                                return@items
                             }
+                            else {
 
-                            UserListItem(
-                                user = user,
-                                unreadCount = unreadCount,
-                                subtitle = previewText,
-                                timeText = formatTimestamp(timestamp),
-                                trailingContent = {
-                                    var showMenu by remember { mutableStateOf(false) }
-                                    Box {
-                                        IconButton(
-                                            onClick = { showMenu = !showMenu }
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Default.MoreVert,
-                                                contentDescription = "Options",
-                                                tint = MaterialTheme.colorScheme.onTertiary
-                                            )
-                                        }
+                                val otherUserID = participants
+                                    .mapNotNull { it as? String }
+                                    .firstOrNull { it != currentUserID } ?: return@items
 
-                                        DropdownMenu(
-                                            expanded = showMenu,
-                                            onDismissRequest = { showMenu = false },
-                                            containerColor = MaterialTheme.colorScheme.surface
-                                        ) {
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                                        Icon(
-                                                            imageVector = Icons.Default.PersonAdd,
-                                                            contentDescription = "Add Friend",
-                                                            tint = MaterialTheme.colorScheme.onTertiary
-                                                        )
-                                                        Spacer(modifier = Modifier.width(8.dp))
-                                                        Text("Add Friend", color = MaterialTheme.colorScheme.onTertiary)
-                                                    }
-                                                },
-                                                onClick = {
-                                                    showMenu = false
-                                                    userToAdd = otherUserID to user.name
+                                if (otherUserID in hideBlockedUsers) return@items
 
-                                                }
-                                            )
+                                val user = userCache.value[otherUserID] ?: User(
+                                    uid = otherUserID,
+                                    name = "Loading Chat...",
+                                    photoUrl = null
+                                )
 
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                                        Icon(
-                                                            imageVector = Icons.Default.Block,
-                                                            contentDescription = "Block User",
-                                                            tint = MaterialTheme.colorScheme.primary
-                                                        )
-                                                        Spacer(modifier = Modifier.width(8.dp))
-                                                        Text("Block User", color = MaterialTheme.colorScheme.primary)
-                                                    }
-                                                },
-                                                onClick = {
-                                                    showMenu = false
-                                                    userToBlock = otherUserID to user.name
-                                                }
-                                            )
-                                        }
-                                    }
-                                },
-                                onClick = {
-                                    navController.navigate(Routes.MESSAGES + "/${user.uid}")
-                                },
-                                onLongPress = {
-                                    selectedChatID = chatID
-                                    showActionSheet = true
+                                val lastMessage = chat["lastMessage"] as? String ?: ""
+                                val timestamp = chat["lastTimestamp"] as? Timestamp
+
+                                val previewText = if (lastMessage.isBlank()) {
+                                    "Start conversation"
+                                } else {
+                                    lastMessage
                                 }
-                            )
+
+                                UserListItem(
+                                    user = user,
+                                    unreadCount = unreadCount,
+                                    subtitle = previewText,
+                                    timeText = formatTimestamp(timestamp),
+                                    trailingContent = {
+                                        var showMenu by remember { mutableStateOf(false) }
+                                        Box {
+                                            IconButton(
+                                                onClick = { showMenu = !showMenu }
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.MoreVert,
+                                                    contentDescription = "Options",
+                                                    tint = MaterialTheme.colorScheme.onTertiary
+                                                )
+                                            }
+
+                                            DropdownMenu(
+                                                expanded = showMenu,
+                                                onDismissRequest = { showMenu = false },
+                                                containerColor = MaterialTheme.colorScheme.surface
+                                            ) {
+                                                DropdownMenuItem(
+                                                    text = {
+                                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                                            Icon(
+                                                                imageVector = Icons.Default.PersonAdd,
+                                                                contentDescription = "Add Friend",
+                                                                tint = MaterialTheme.colorScheme.onTertiary
+                                                            )
+                                                            Spacer(modifier = Modifier.width(8.dp))
+                                                            Text(
+                                                                "Add Friend",
+                                                                color = MaterialTheme.colorScheme.onTertiary
+                                                            )
+                                                        }
+                                                    },
+                                                    onClick = {
+                                                        showMenu = false
+                                                        userToAdd = otherUserID to user.name
+
+                                                    }
+                                                )
+
+                                                DropdownMenuItem(
+                                                    text = {
+                                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                                            Icon(
+                                                                imageVector = Icons.Default.Block,
+                                                                contentDescription = "Block User",
+                                                                tint = MaterialTheme.colorScheme.primary
+                                                            )
+                                                            Spacer(modifier = Modifier.width(8.dp))
+                                                            Text(
+                                                                "Block User",
+                                                                color = MaterialTheme.colorScheme.primary
+                                                            )
+                                                        }
+                                                    },
+                                                    onClick = {
+                                                        showMenu = false
+                                                        userToBlock = otherUserID to user.name
+                                                    }
+                                                )
+                                            }
+                                        }
+                                    },
+                                    onClick = {
+                                        navController.navigate(Routes.MESSAGES + "/${user.uid}")
+                                    },
+                                    onLongPress = {
+                                        selectedChatID = chatID
+                                        showActionSheet = true
+                                    }
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -289,6 +289,18 @@ class ChatRepositoryViewModel (
         )
     }
 
+    fun callSendPingGroupMessage(
+        senderUserID: String,
+        chatID: String,
+        location: CampusLocation
+    ) {
+        chatRepository.sendPinGroupMessage(
+            senderUserID = senderUserID,
+            chatID = chatID,
+            location = location
+        )
+    }
+
     fun callCreateGroupChat(
         creatorUserID: String,
         participantIDs: List<String>,

--- a/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/phinui/viewmodel/ChatRepositoryViewModel.kt
@@ -92,6 +92,13 @@ class ChatRepositoryViewModel (
         val filterOutFriends = approvedChats.value.filter{ chat ->
             val participants = chat["participants"] as? List<*> ?: return@filter false
 
+            val chatType = chat["type"] as? String
+                ?: if (participants.size > 2) "group" else "direct"
+
+            if (chatType != "direct") {
+                return@filter false
+            }
+
             val otherUserID = participants
                 .mapNotNull { it as? String }
                 .firstOrNull{ it != currentUserID }


### PR DESCRIPTION
New:
- Users can send campus pins in group chats
- A number is displayed next to the group chat name to show the number of new messages
- The number notification for the "Friends" tab will also include the group chats

Fix:
- General tabs no longer tracks group chats
- Preview messages for the chats in the general tab no longer track/show what was sent in a group chat