### PR TITLE
Messaging - delete group chat from firebase

### DIFF
--- a/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
+++ b/app/src/main/java/com/example/phinui/components/messages/ChatRepository.kt
@@ -337,10 +337,28 @@ class ChatRepository {
                     val participants = snapshot.get("participants") as? List<String> ?: emptyList()
                     val isFriendChat = snapshot.getBoolean("isFriendChat") ?: false
 
-                    val bothDeleted = participants.all { deletedBy.contains(it) }
+                    val chatType = snapshot["type"] as? String ?: "direct"
 
-                    if (bothDeleted && !isFriendChat) {
+                    val allDeleted = participants.all { deletedBy.contains(it) }
+
+                    if (allDeleted && !isFriendChat) {
                         chatRef.update("requestState", "none")
+                            .addOnSuccessListener {
+                                if (chatType == "group") {
+                                    chatRef.collection("messages")
+                                        .get()
+                                        .addOnSuccessListener { removeMessage ->
+                                            val messagesBatch = database.batch()
+                                            removeMessage.documents.forEach { messagesDoc ->
+                                                messagesBatch.delete(messagesDoc.reference)
+                                            }
+
+                                            messagesBatch.commit().addOnSuccessListener {
+                                                chatRef.delete()
+                                            }
+                                        }
+                                }
+                            }
                     }
                 }
             }


### PR DESCRIPTION
- When all users from the same group chat delete the group chat, that group chat will be deleted from firebase.
- Only group chats are affected. 
- Friends and General chats should still get their messages back if the two participants both delete the same 1 on 1 chat but resend a new message afterwards