### PR TITLE
group chat notifs

### DIFF
--- a/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
+++ b/app/src/main/java/com/example/phinui/navigation/PhinNavHost.kt
@@ -258,6 +258,11 @@ fun PhinNavHost(
                 navArgument("groupName") {
                     type = NavType.StringType
                 }
+            ),
+            deepLinks = listOf(
+                navDeepLink {
+                    uriPattern = "phin://group_messages/{chatID}/{groupName}"
+                }
             )
         ) { backStackEntry ->
             val currentUserID = FirebaseAuth.getInstance().currentUser?.uid ?: ""

--- a/functions/acceptInviteNotif.js
+++ b/functions/acceptInviteNotif.js
@@ -18,7 +18,7 @@ exports.sendAcceptInviteNotification = onDocumentUpdated(
         return null;
       }
 
-      const {type, participants: beforeParticipants} = before;
+      const {senderID, type, participants: beforeParticipants} = before;
       const {deleted, participants: afterParticipants} = after;
       const chatId = event.params.chatId;
 
@@ -27,6 +27,8 @@ exports.sendAcceptInviteNotification = onDocumentUpdated(
 
       // ignore deleted messages
       if (deleted) return null;
+
+      const receiverId = senderID;
 
       let senderId = null;
 
@@ -40,10 +42,6 @@ exports.sendAcceptInviteNotification = onDocumentUpdated(
           break;
         }
       }
-
-      const receiverId = Object.keys(afterParticipants).find(
-          (userId) => userId !== senderId,
-      );
 
       if (!senderId) {
         console.log("Missing senderId");
@@ -61,6 +59,15 @@ exports.sendAcceptInviteNotification = onDocumentUpdated(
 
         if (!chatData || !chatData.participants) return null;
 
+        const mutedBy = chatData.mutedBy || [];
+
+        if (mutedBy.includes(receiverId)) {
+          console.log(
+              `Chat is muted by ${receiverId}. Skipping notification`,
+          );
+          return null;
+        }
+
         const receiverDoc = await db.collection("users").doc(receiverId).get();
         const receiverData = receiverDoc.data();
 
@@ -77,6 +84,12 @@ exports.sendAcceptInviteNotification = onDocumentUpdated(
 
         const senderDoc = await db.collection("users").doc(senderId).get();
         const senderName = senderDoc.data() ? senderDoc.data().name : "Someone";
+
+        const isGroupChat = chatData.type === "group";
+
+        const uri = isGroupChat ?
+        `phin://group_messages/${chatId}/${chatData.groupName}` :
+        `phin://messages/${senderID}`;
 
         const now = Date.now();
         const lastActiveTime =
@@ -99,7 +112,7 @@ exports.sendAcceptInviteNotification = onDocumentUpdated(
             title: "Study Session Invite Accepted",
             fromUid: senderId,
             body: `${senderName} accepted your study session invite`,
-            uri: `phin://messages/${senderId}`,
+            uri: uri,
           },
         });
 

--- a/functions/inviteStudySessionNotif.js
+++ b/functions/inviteStudySessionNotif.js
@@ -10,31 +10,14 @@ exports.sendInviteNotification = onDocumentCreated(
       const message = event.data.data();
       if (!message) return null;
 
-      const {deleted, type, participants} = message;
+      const {senderID, deleted, type} = message;
       const chatId = event.params.chatId;
 
       // check if it's a study session invite
-      if (type !== "invitation" || !participants) return null;
+      if (type !== "invitation" || !senderID) return null;
 
       // ignore deleted messages
       if (deleted) return null;
-
-      const senderId = Object.keys(participants).find(
-          (userId) => participants[userId] === "ACCEPTED",
-      );
-
-      const receiverId = Object.keys(participants).find(
-          (userId) => participants[userId] === "PENDING",
-      );
-
-      if (!senderId) {
-        console.log("Missing senderId");
-        return null;
-      } else if (!receiverId) {
-        console.log("Missing receiverId");
-        return null;
-      }
-
 
       try {
         const db = admin.firestore();
@@ -42,54 +25,104 @@ exports.sendInviteNotification = onDocumentCreated(
         const chatDoc = await db.collection("chats").doc(chatId).get();
         const chatData = chatDoc.data();
 
-        if (!chatData || !chatData.participants) return null;
+        if (!chatData) return null;
 
-        const receiverDoc = await db.collection("users").doc(receiverId).get();
-        const receiverData = receiverDoc.data();
+        const mutedBy = chatData.mutedBy || [];
+        const participants = chatData.participants || [];
 
-        const fcmToken = receiverData ? receiverData.fcmToken : null;
-        const activeChatID = receiverData ? receiverData.activeChatID : null;
-        const lastActive = receiverData ? receiverData.lastActive : null;
+        const receiverIds = participants.filter(
+            (uid) => uid !== senderID,
+        );
 
-        if (!fcmToken) {
-          console.log("No FCM token for receiving user");
-          return null;
-        } else {
-          console.log("FCM token for invite: ", fcmToken);
-        }
+        if (!receiverIds.length) return null;
 
-        const senderDoc = await db.collection("users").doc(senderId).get();
+        const isGroupChat = chatData.type === "group";
+        const uri = isGroupChat ?
+        `phin://group_messages/${chatId}/${chatData.groupName}` :
+        `phin://messages/${senderID}`;
+
+        const senderDoc = await db.collection("users").doc(senderID).get();
         const senderName = senderDoc.data() ? senderDoc.data().name : "Someone";
 
-        const now = Date.now();
-        const lastActiveTime =
-            lastActive && typeof lastActive.toMillis === "function" ?
-            lastActive.toMillis() : 0;
+        // send notif to every receiver
+        await Promise.all(
+            receiverIds.map(async (receiverId) => {
+              try {
+              // skip muted users
+                if (mutedBy.includes(receiverId)) {
+                  console.log(
+                      `Chat is muted by ${receiverId}. Skipping notification`,
+                  );
+                  return;
+                }
 
-        const isInChat = activeChatID === chatId;
-        const isActive = (now - lastActiveTime) < 120000;
+                const receiverDoc = await db
+                    .collection("users")
+                    .doc(receiverId)
+                    .get();
 
-        // only send if receiver is not on chat screen
-        if (isInChat && isActive) {
-          console.log("User is currently in this chat. Skipping notification");
-          return null;
-        }
+                const receiverData = receiverDoc.data();
 
-        await admin.messaging().send({
-          token: fcmToken,
-          data: {
-            type: "INVITE",
-            title: "Study Session Invite",
-            body: `${senderName} sent you a study session invite`,
-            uri: `phin://messages/${senderId}`,
-          },
-        });
+                if (!receiverData) return;
 
-        console.log("Study session invite notification sent!");
+                const fcmToken = receiverData.fcmToken;
+                const activeChatID = receiverData.activeChatID;
+                const lastActive = receiverData.lastActive;
+
+                if (!fcmToken) {
+                  console.log(`No FCM token for user ${receiverId}`);
+                  return;
+                } else {
+                  console.log(
+                      `FCM token for user ${receiverId} is ${fcmToken}`,
+                  );
+                }
+
+                const now = Date.now();
+
+                const lastActiveTime =
+              lastActive &&
+              typeof lastActive.toMillis === "function" ?
+              lastActive.toMillis() :
+              0;
+
+                const isInChat = activeChatID === chatId;
+                const isActive = (now - lastActiveTime) < 120000;
+
+                // skip notif if currently viewing chat
+                if (isInChat && isActive) {
+                  console.log(
+                      `${receiverId} is currently in chat. Skipping`,
+                  );
+                  return;
+                }
+
+                await admin.messaging().send({
+                  token: fcmToken,
+                  data: {
+                    type: "INVITE",
+                    title: "Study Session Invite",
+                    body: `${senderName} sent you a study session invite`,
+                    uri: uri,
+                  },
+                });
+
+                console.log(`Study session notif sent to ${receiverId}`);
+              } catch (err) {
+                console.error(
+                    `Error sending study session notif to ${receiverId}: `,
+                    err,
+                );
+              }
+            }),
+        );
+
         return null;
       } catch (error) {
         console.error(
-            "Error sending study session invite notification: ", error);
+            "Error sending study session notifications: ",
+            error,
+        );
         return null;
       }
     },

--- a/functions/newMessageNotif.js
+++ b/functions/newMessageNotif.js
@@ -23,67 +23,102 @@ exports.sendNewMessageNotification = onDocumentCreated(
 
         const chatDoc = await db.collection("chats").doc(chatId).get();
         const chatData = chatDoc.data();
+
+        if (!chatData) return null;
+
         const mutedBy = chatData.mutedBy || [];
+        const participants = chatData.participants || [];
 
-        if (!chatData || !chatData.participants) return null;
-
-        const receiverId = chatData.participants.find(
+        const receiverIds = participants.filter(
             (uid) => uid !== senderID,
         );
 
-        if (!receiverId) return null;
+        if (!receiverIds.length) return null;
 
-        if (mutedBy.includes(receiverId)) {
-          console.log("Chat is muted by receiver. Skipping notification");
-          return null;
-        }
-
-        const receiverDoc = await db.collection("users").doc(receiverId).get();
-        const receiverData = receiverDoc.data();
-
-        const fcmToken = receiverData ? receiverData.fcmToken : null;
-        const activeChatID = receiverData ? receiverData.activeChatID : null;
-        const lastActive = receiverData ? receiverData.lastActive : null;
-
-        if (!fcmToken) {
-          console.log("No FCM token for receiving user");
-          return null;
-        } else {
-          console.log("FCM token for messaging: ", fcmToken);
-        }
+        const isGroupChat = chatData.type === "group";
+        const uri = isGroupChat ?
+        `phin://group_messages/${chatId}/${chatData.groupName}` :
+        `phin://messages/${senderID}`;
 
         const senderDoc = await db.collection("users").doc(senderID).get();
         const senderName = senderDoc.data() ? senderDoc.data().name : "Someone";
 
-        const now = Date.now();
-        const lastActiveTime =
-          lastActive && typeof lastActive.toMillis === "function" ?
-          lastActive.toMillis() : 0;
+        // send notif to every receiver
+        await Promise.all(
+            receiverIds.map(async (receiverId) => {
+              try {
+              // skip muted users
+                if (mutedBy.includes(receiverId)) {
+                  console.log(
+                      `Chat is muted by ${receiverId}. Skipping notification`,
+                  );
+                  return;
+                }
 
-        const isInChat = activeChatID === chatId;
-        const isActive = (now - lastActiveTime) < 120000;
+                const receiverDoc = await db
+                    .collection("users")
+                    .doc(receiverId)
+                    .get();
+                const receiverData = receiverDoc.data();
 
-        // only send if user is not on the chat screen
-        if (isInChat && isActive) {
-          console.log("User is currently in this chat. Skipping notification");
-          return null;
-        }
+                if (!receiverData) return;
 
-        await admin.messaging().send({
-          token: fcmToken,
-          data: {
-            type: "NEW_MESSAGE",
-            title: "New Message",
-            fromUid: senderID,
-            body: `${senderName} sent you a message`,
-            uri: `phin://messages/${senderID}`,
-          },
-        });
+                const fcmToken = receiverData.fcmToken;
+                const activeChatID = receiverData.activeChatID;
+                const lastActive = receiverData.lastActive;
 
-        console.log("New message notification sent!");
+                if (!fcmToken) {
+                  console.log(`No FCM token for user ${receiverId}`);
+                  return;
+                } else {
+                  console.log(
+                      `FCM token for user ${receiverId} is ${fcmToken}`,
+                  );
+                }
+
+                const now = Date.now();
+
+                const lastActiveTime =
+                lastActive &&
+                typeof lastActive.toMillis === "function" ?
+                lastActive.toMillis() :
+                0;
+
+                const isInChat = activeChatID === chatId;
+                const isActive = (now - lastActiveTime) < 120000;
+
+                // skip notif if currently viewing chat
+                if (isInChat && isActive) {
+                  console.log(
+                      `${receiverId} is currently in chat. Skipping`,
+                  );
+                  return;
+                }
+
+                await admin.messaging().send({
+                  token: fcmToken,
+                  data: {
+                    type: "NEW_MESSAGE",
+                    title: "New Message",
+                    fromUid: senderID,
+                    body: `${senderName} sent you a message`,
+                    uri: uri,
+                  },
+                });
+
+                console.log(`Notification sent to ${receiverId}`);
+              } catch (err) {
+                console.error(
+                    `Error sending notification to ${receiverId}: `,
+                    err,
+                );
+              }
+            }),
+        );
+
         return null;
       } catch (error) {
-        console.error("Error sending new message notification: ", error);
+        console.error("Error sending new message notifications: ", error);
         return null;
       }
     },

--- a/functions/pinNotif.js
+++ b/functions/pinNotif.js
@@ -24,67 +24,103 @@ exports.sendPinNotification = onDocumentCreated(
 
         const chatDoc = await db.collection("chats").doc(chatId).get();
         const chatData = chatDoc.data();
+
+        if (!chatData) return null;
+
         const mutedBy = chatData.mutedBy || [];
+        const participants = chatData.participants || [];
 
-        if (!chatData || !chatData.participants) return null;
-
-        const receiverId = chatData.participants.find(
+        const receiverIds = participants.filter(
             (uid) => uid !== senderID,
         );
 
-        if (!receiverId) return null;
+        if (!receiverIds.length) return null;
 
-        if (mutedBy.includes(receiverId)) {
-          console.log("Chat is muted by receiver. Skipping notification");
-          return null;
-        }
-
-        const receiverDoc = await db.collection("users").doc(receiverId).get();
-        const receiverData = receiverDoc.data();
-
-        const fcmToken = receiverData ? receiverData.fcmToken : null;
-        const activeChatID = receiverData ? receiverData.activeChatID : null;
-        const lastActive = receiverData ? receiverData.lastActive : null;
-
-        if (!fcmToken) {
-          console.log("No FCM token for receiving user");
-          return null;
-        } else {
-          console.log("FCM token for messaging: ", fcmToken);
-        }
+        const isGroupChat = chatData.type === "group";
+        const uri = isGroupChat ?
+        `phin://group_messages/${chatId}/${chatData.groupName}` :
+        `phin://messages/${senderID}`;
 
         const senderDoc = await db.collection("users").doc(senderID).get();
         const senderName = senderDoc.data() ? senderDoc.data().name : "Someone";
 
-        const now = Date.now();
-        const lastActiveTime =
-                lastActive && typeof lastActive.toMillis === "function" ?
-                lastActive.toMillis() : 0;
+        // send notif to every receiver
+        await Promise.all(
+            receiverIds.map(async (receiverId) => {
+              try {
+              // skip muted users
+                if (mutedBy.includes(receiverId)) {
+                  console.log(
+                      `Chat is muted by ${receiverId}. Skipping notification`,
+                  );
+                  return;
+                }
 
-        const isInChat = activeChatID === chatId;
-        const isActive = (now - lastActiveTime) < 120000;
+                const receiverDoc = await db
+                    .collection("users")
+                    .doc(receiverId)
+                    .get();
 
-        // only send if user is not on chat screen
-        if (isInChat && isActive) {
-          console.log("User is currently in this chat. Skipping notification");
-          return null;
-        }
+                const receiverData = receiverDoc.data();
 
-        await admin.messaging().send({
-          token: fcmToken,
-          data: {
-            type: "PIN",
-            title: "Incoming Pin",
-            fromUid: senderID,
-            body: `${senderName} sent you a pin`,
-            uri: `phin://messages/${senderID}`,
-          },
-        });
+                if (!receiverData) return;
 
-        console.log("Pin notification sent!");
+                const fcmToken = receiverData.fcmToken;
+                const activeChatID = receiverData.activeChatID;
+                const lastActive = receiverData.lastActive;
+
+                if (!fcmToken) {
+                  console.log(`No FCM token for user ${receiverId}`);
+                  return;
+                } else {
+                  console.log(
+                      `FCM token for usre ${receiverId} is ${fcmToken}`,
+                  );
+                }
+
+                const now = Date.now();
+
+                const lastActiveTime =
+              lastActive &&
+              typeof lastActive.toMillis === "function" ?
+              lastActive.toMillis() :
+              0;
+
+                const isInChat = activeChatID === chatId;
+                const isActive = (now - lastActiveTime) < 120000;
+
+                // skip if currently viewing chat
+                if (isInChat && isActive) {
+                  console.log(
+                      `${receiverId} is currently in chat. Skipping`,
+                  );
+                  return;
+                }
+
+                await admin.messaging().send({
+                  token: fcmToken,
+                  data: {
+                    type: "PIN",
+                    title: "Incoming Pin",
+                    fromUid: senderID,
+                    body: `${senderName} sent you a pin`,
+                    uri: uri,
+                  },
+                });
+
+                console.log(`Pin notification sent to ${receiverId}`);
+              } catch (err) {
+                console.error(
+                    `Error sending pin notification to ${receiverId}: `,
+                    err,
+                );
+              }
+            }),
+        );
+
         return null;
       } catch (error) {
-        console.error("Error sending pin notification: ", error);
+        console.error("Error sending pin notifications: ", error);
         return null;
       }
     },


### PR DESCRIPTION
Code has been changed for new message, study session invite, and pin notifications to work for group chats as well now. 
For all three, notifs should get sent to the remaining participants who are not the sender. For accepted study session invites, the notif should only be sent to the user who originally created the invite (though this can be changed depending on what we think is better).

To test:
At least three emulators have to be open simultaneously to make sure multiple users are receiving the notifs at the same time. If they aren't firing due to emulator issues, you can also observe the behavior of the notifs via google cloud console's logs (I can provide the link if anyone wants to see it!). 
Notifs should still follow correct behavior if the user is actively viewing the chat or if the chat is muted.