### PR TITLE
got rid of the bottom bar menu subtitle

### DIFF
--- a/app/src/main/java/com/example/phinui/components/BottomBarDropdown.kt
+++ b/app/src/main/java/com/example/phinui/components/BottomBarDropdown.kt
@@ -35,7 +35,6 @@ fun BottomBarDropdown(
             value = selected.title,
             onValueChange = {},
             readOnly = true,
-            label = { Text("Bottom Bar") },
             trailingIcon = {
                 ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
             },


### PR DESCRIPTION
Bottom bar drop down menu in the settings screen used to say "Bottom Bar" twice. Now it only says it once